### PR TITLE
Add require option to Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ gem install mailgun-ruby
 Gemfile:
 
 ```ruby
-gem 'mailgun-ruby', "~>1.0.2"
+gem 'mailgun-ruby', '~>1.0.2', require: 'mailgun'
 ```
 
 Include


### PR DESCRIPTION
If you're using Rails, or anything else that calls `Bundler.require`, you need this option to have things work correctly (otherwise, bundler will try to require `'mailgun-ruby'`).
