### PR TITLE
Fixes Mail Merge issues

### DIFF
--- a/lib/mailgun/messages/batch_message.rb
+++ b/lib/mailgun/messages/batch_message.rb
@@ -96,6 +96,9 @@ module Mailgun
 
     def send_message(message)
       simple_setter("recipient-variables", JSON.generate(@recipient_variables))
+      if @message.has_key?("recipient-variables")
+        @message["recipient-variables"] = @message["recipient-variables"].first
+      end
       response = @client.send_message(@domain, @message).to_h!
       message_id = response['id'].gsub(/\>|\</, '')
       @message_ids[message_id] = count_recipients()


### PR DESCRIPTION
This fixes the mail-merge issues with the Gem. Apparently, the `recipient-variables` was wrapped in an array and that was causing issues. By removing it from the parent array solves the problem.
