### PR TITLE
Fix file attachment logic

### DIFF
--- a/lib/mailgun/messages/message_builder.rb
+++ b/lib/mailgun/messages/message_builder.rb
@@ -276,7 +276,8 @@ module Mailgun
         raise ParameterError.new("Unable to access attachment file object.")
       end
       if !filename.nil?
-        attachment.instance_eval "def original_filename; '#{filename}'; end"
+        attachment.instance_variable_set :@original_filename, filename
+        attachment.instance_eval "def original_filename; @original_filename; end"
       end
       complex_setter(disposition, attachment)
     end

--- a/spec/unit/messages/message_builder_spec.rb
+++ b/spec/unit/messages/message_builder_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'stringio'
 
 describe 'MessageBuilder attribute readers' do
   it 'should be readable' do
@@ -156,6 +157,13 @@ describe 'The method add_attachment' do
 
     file_paths.each {|item| @mb_obj.add_attachment(item)}
     @mb_obj.message[:attachment].length.should eq(2)
+  end
+
+  it 'adds file-like objects to the message object' do
+    io = StringIO.new
+    io << File.binread(File.dirname(__FILE__) + "/sample_data/mailgun_icon.png")
+
+    @mb_obj.add_attachment io, 'mailgun_icon.png'
   end
 end
 


### PR DESCRIPTION
The logic before had an error where if the attachment was not a File
object, it would short-circuit and never fallback to the
`respond_to?(:read)` check. This fixes that error; a test was added to
ensure it file-like objects are allowed now.

In addition, the `add_attachment` and `add_inline_image` methods were
effectively identical, so I refactored them to call a new shared method called `add_file`.
