### PR TITLE
Use environment variables for API keys

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,8 @@ Bundler.setup(:development)
 require 'mailgun'
 require_relative 'unit/connection/test_client'
 
-# INSERT YOUR API KEYS HERE
+# Call tests like this:
+# MAILGUN_API_KEY=abcd MAILGUN_PUBLIC_KEY=1234 bundle exec rspec
 APIKEY = ENV['MAILGUN_API_KEY']
 PUB_APIKEY = ENV['MAILGUN_PUBLIC_KEY']
 APIHOST = "api.mailgun.net"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,8 +8,8 @@ require 'mailgun'
 require_relative 'unit/connection/test_client'
 
 # INSERT YOUR API KEYS HERE
-APIKEY = "key"
-PUB_APIKEY = "pubkey"
+APIKEY = ENV['MAILGUN_API_KEY']
+PUB_APIKEY = ENV['MAILGUN_PUBLIC_KEY']
 APIHOST = "api.mailgun.net"
 APIVERSION = "v2"
-SSL= true
+SSL = true


### PR DESCRIPTION
Since we have to use our own keys to run the tests on this gem, support using environment variables so we don’t have to edit this file and remember to revert it back before committing. This way we can run tests like:

`MAILGUN_API_KEY=abcd MAILGUN_PUBLIC_KEY=1234 bundle exec rspec`