### PR TITLE
Validate email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ message_id = result['id']
 message = result['message']
 ```
 
+Email validation
+--------
+For email validation you need to build the client using your Mailgun public API key.
+Here's an example of how to use the call:
+
+```ruby
+mg_client = Mailgun::Client.new("your-public-api-key")
+result = mg_client.validate_email('test@test-mail-domain.com').to_h!
+
+is_valid = result['is_valid']
+alternatives = result['did_you_mean']
+```
+
 Debugging
 ---------
 

--- a/lib/mailgun.rb
+++ b/lib/mailgun.rb
@@ -57,6 +57,13 @@ module Mailgun
       end
     end
 
+    # Validate an email address
+    #
+    # @param [String] email This is the email address you wish to validate
+    def validate_email(email)
+      get('/address/validate', {address: email})
+    end
+
     # Generic Mailgun POST Handler
     #
     # @param [String] resource_path This is the API resource you wish to interact


### PR DESCRIPTION
Adding support to call the /address/validate public endpoint of the Mailgun API via the validate_email call.
