### PR TITLE
Fix Snippets.md to contain correct set_from_address syntax

### DIFF
--- a/Snippets.md
+++ b/Snippets.md
@@ -68,10 +68,10 @@ mg_client.send_message "sending_domain.com", data
 ```ruby
 mb_obj = Mailgun::MessageBuilder.new
 
-mb_obj.set_from_address :from, "sender@example.com", {'first' => 'Sending', 'last' => 'User'}
+mb_obj.set_from_address "sender@example.com", {'first' => 'Sending', 'last' => 'User'}
 mb_obj.add_recipient :to, "recipient@example.com", {'first' => 'Recipient', 'last' => 'User'}
-mb_obj.set_subject :subject, "This is the subject!"
-mb_obj.set_text_body :text, "This is the text body."
+mb_obj.set_subject "This is the subject!"
+mb_obj.set_text_body "This is the text body."
 
 mg_client.send_message "sending_domain.com", mb_obj
 ```
@@ -82,10 +82,10 @@ mg_client.send_message "sending_domain.com", mb_obj
 bm_obj = Mailgun::BatchMessage.new
 
 # Build message using Message Builder
-bm_obj.set_from_address :from, "sender@example.com", {'first' => 'Sending', 'last' => 'User'}
+bm_obj.set_from_address "sender@example.com", {'first' => 'Sending', 'last' => 'User'}
 bm_obj.set_message_id("<20141014000000.11111.11111@example.com>") # optional
-bm_obj.set_subject :subject, "This is the subject!"
-bm_obj.set_text_body :text, "This is the text body."
+bm_obj.set_subject "This is the subject!"
+bm_obj.set_text_body "This is the text body."
 
 # Loop and add unlimited recipients (batch jobs will fire when thresholds reached)
 bm_obj.add_recipient :to, "a_user@example.com"

--- a/spec/unit/messages/message_builder_spec.rb
+++ b/spec/unit/messages/message_builder_spec.rb
@@ -143,6 +143,24 @@ describe 'The method set_text_body' do
   end
 end
 
+describe 'The method set_from_address' do
+  before(:each) do
+    @mb_obj = Mailgun::MessageBuilder.new
+  end
+  it 'sets the from address' do
+    the_from_address = 'test@mailgun.com'
+    @mb_obj.set_from_address(the_from_address)
+    @mb_obj.message[:from].should eq([the_from_address])
+  end
+  it 'sets the from address with metadata' do
+    the_from_address = 'test@mailgun.com'
+    the_first_name = 'Magilla'
+    the_last_name = 'Gorilla'
+    @mb_obj.set_from_address(the_from_address, {'first' => the_first_name, 'last' => the_last_name})
+    @mb_obj.message[:from].should eq(["'#{the_first_name} #{the_last_name}' <#{the_from_address}>"])
+  end
+end
+
 describe 'The method add_attachment' do
   before(:each) do
     @mb_obj = Mailgun::MessageBuilder.new


### PR DESCRIPTION
[Snippets.md](Snippets.md) contains the wrong syntax for several methods on MessageBuilder. I've fixed these and included two unit tests for `set_from_message`.

Fixes #37 
