### PR TITLE
Add reference to set_html_body in Messages.md

### DIFF
--- a/Messages.md
+++ b/Messages.md
@@ -33,6 +33,8 @@ mb_obj.add_recipient(:cc, "sally.doe@example.com", {"first" => "Sally", "last" =
 mb_obj.set_subject("A message from the Ruby SDK using Message Builder!");
 # Define the body of the message.
 mb_obj.set_text_body("This is the text body of the message!");
+# Define the HTML text of the message
+mb_obj.set_html_body("<html><body><p>This is the text body of the message</p></body></html>");
 # Set the Message-Id header. Pass in a valid Message-Id.
 mb_obj.set_message_id("<20141014000000.11111.11111@example.com>")
 # Clear the Message-Id header. Pass in nil or empty string.


### PR DESCRIPTION
This reference was not present previously, which meant that I had to go into [/lib/mailgun/messages/message_builder.rb](https://github.com/mailgun/mailgun-ruby/blob/master/lib/mailgun/messages/message_builder.rb#L82) to find the name of the function. 

(Although, the name of the function is intuitive, it's better to have it here, as it is a very important part of the REQUEST)
