### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ gem install mailgun-ruby
 Gemfile:
 
 ```ruby
-gem 'mailgun-ruby', '~>1.0.5', require: 'mailgun'
+gem 'mailgun-ruby', '~> 1.1', require: 'mailgun'
 ```
 
 Include


### PR DESCRIPTION
Correct version. Error when bundling:

> Could not find gem 'mailgun-ruby (~> 1.0.5) ruby' in any of the gem sources listed in
your Gemfile or installed on this machine.