### PR TITLE
"mailgun-ruby" does not exist in rubygems

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ gem install mailgun-ruby
 Gemfile:
 
 ```ruby
-gem 'mailgun-ruby', '~>1.0.5', require: 'mailgun'
+gem 'mailgun', '~>1.0.5', require: 'mailgun'
 ```
 
 Include


### PR DESCRIPTION
I've changed it into "mailgun" which does exists :)