### PR TITLE
Test mode implementation, #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ gem install mailgun-ruby
 Gemfile:
 
 ```ruby
-gem 'mailgun-ruby', '~>1.1.1'
+gem 'mailgun-ruby', '~>1.1.2'
 ```
 
 Usage
@@ -45,7 +45,7 @@ Or obtain the last couple log items:
 
 ```ruby
 # First, instantiate the Mailgun Client with your API key
-mg_client = Mailgun::Client.new 'your-api-key'
+mg_client = Mailgun::Client.new 'your-secret-api-key'
 
 # Define the domain you wish to query
 domain = 'example.com'
@@ -60,7 +60,7 @@ Rails
 The library can be initialized with a Rails initializer containing similar:
 ```ruby
 Mailgun.configure do |config|
-  config.api_key = 'your-secret-key'
+  config.api_key = 'your-secret-api-key'
 end
 ```
 Or have the initializer read your environment setting if you perfer.

--- a/lib/mailgun/response.rb
+++ b/lib/mailgun/response.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 module Mailgun
   # A Mailgun::Response object is instantiated for each response generated
   # by the Client request. The Response object supports deserialization of
@@ -9,6 +11,11 @@ module Mailgun
     # All responses have a payload and a code corresponding to http, though
     #   slightly different
     attr_accessor :body, :code
+
+    def self.from_hash(h)
+      # Create a "fake" response object with the data passed from h
+      self.new OpenStruct.new(h)
+    end
 
     def initialize(response)
       @body = response.body

--- a/lib/mailgun/version.rb
+++ b/lib/mailgun/version.rb
@@ -1,4 +1,4 @@
 # It's the version. Yeay!
 module Mailgun
-  VERSION = '1.1.1'
+  VERSION = '1.1.2'
 end

--- a/spec/integration/mailgun_spec.rb
+++ b/spec/integration/mailgun_spec.rb
@@ -54,6 +54,28 @@ describe 'The method send_message()', vcr: vcr_opts do
     expect(result.body).to include("id")
   end
 
+  it 'fakes message send while in *client* test mode' do
+    @mg_obj.enable_test_mode!
+
+    expect(@mg_obj.test_mode?).to eq(true)
+
+    data = { :from => "joe@#{@domain}",
+             :to => "bob@#{@domain}",
+             :subject => "Test",
+             :text => "Test Data" }
+
+    result = @mg_obj.send_message(@domain, data)
+
+    result.to_h!
+
+    expect(result.body).to include("message")
+    expect(result.body).to include("id")
+
+    expect(result.code).to eq(200)
+    expect(result.body['id']).to eq("test-mode-mail@localhost")
+    expect(result.body['message']).to eq("Queued. Thank you.")
+  end
+
   it 'sends a message builder message in test mode.' do
     mb_obj = Mailgun::MessageBuilder.new()
     mb_obj.from("sender@#{@domain}", {'first' => 'Sending', 'last' => 'User'})

--- a/spec/unit/mailgun_spec.rb
+++ b/spec/unit/mailgun_spec.rb
@@ -25,9 +25,9 @@ describe 'The method send_message()' do
 
   it 'sends a message' do
     data = { 'from' => 'joe@test.com',
-                    'to' => 'bob@example.com',
-                    'subject' => 'Test',
-                    'text' => 'Test Data'}
+             'to' => 'bob@example.com',
+             'subject' => 'Test',
+             'text' => 'Test Data' }
     result = @mg_obj.send_message("testdomain.com", data)
 
     result.to_h!
@@ -42,7 +42,7 @@ describe 'The method send_message()' do
     result = @mg_obj.send_message("testdomain.com", data)
 
     result.to_h!
-    
+
     expect(result.body).to include("message")
     expect(result.body).to include("id")
   end
@@ -61,7 +61,7 @@ describe 'The method post()' do
     result = @mg_obj.post("#{@domain}/messages", data)
 
     result.to_h!
-    
+
     expect(result.body).to include("message")
     expect(result.body).to include("id")
   end
@@ -81,7 +81,7 @@ describe 'The method put()' do
     result = @mg_obj.put("lists/#{@list_address}/members#{@member_address}", data)
 
     result.to_h!
-    
+
     expect(result.body).to include("member")
     expect(result.body["member"]).to include("vars")
     expect(result.body["member"]["vars"]).to include("age")
@@ -104,7 +104,7 @@ describe 'The method get()' do
     result = @mg_obj.get("#{@domain}/bounces", query_string)
 
     result.to_h!
-    
+
     expect(result.body).to include("total_count")
     expect(result.body).to include("items")
   end
@@ -120,7 +120,7 @@ describe 'The method delete()' do
     result = @mg_obj.delete("#{@domain}/campaigns/ABC123")
 
     result.to_h!
-    
+
     expect(result.body).to include("message")
     expect(result.body).to include("id")
   end


### PR DESCRIPTION
Super basic implementation of a "test mode" allowing users to easily stub calls that send emails.

Initially, it is just for stubbing the message sending routine, but can be expanded to stub other API calls if necessary.

Test mode is also tested. :joy:

*EDIT*: Version has also been bumped to 1.1.2 for this feature.