### PR TITLE
Remove leading newline from MIME string.

### DIFF
--- a/Snippets.md
+++ b/Snippets.md
@@ -41,8 +41,7 @@ mg_client.send_message "sending_domain.com", data
 
 ```ruby
 # Don't include a file, pull the file to a string
-mime_string = '
-From: Bob Sample <example@example.com>
+mime_string = 'From: Bob Sample <example@example.com>
 MIME-Version: 1.0
 Content-Type: multipart/mixed;
 boundary="--boundary-goes-here--"


### PR DESCRIPTION
The leading newline on the MIME string prevents it from being processed correctly by the API. Thanks @clhammer :)