### PR TITLE
Document what to require

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Usage
 Here's how to send a message using the library:
 
 ```ruby
+require 'mailgun' 
+
 # First, instantiate the Mailgun Client with your API key
 mg_client = Mailgun::Client.new 'your-api-key'
 


### PR DESCRIPTION
This is especially useful for non-Rails app. It reduces guesswork (e.g. require 'mailgun-ruby' or 'mailgun'?), and would accelerate time to create a working version.