### PR TITLE
Autoload Railgun in Rails

### DIFF
--- a/lib/mailgun-ruby.rb
+++ b/lib/mailgun-ruby.rb
@@ -1,1 +1,2 @@
 require 'mailgun'
+require 'railgun' if defined?(Rails)

--- a/lib/railgun.rb
+++ b/lib/railgun.rb
@@ -1,6 +1,4 @@
-require 'action_mailer'
-require 'active_support/rescuable'
-
+require 'railgun/railtie'
 require 'railgun/attachment'
 require 'railgun/errors'
 require 'railgun/mailer'

--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -158,5 +158,3 @@ module Railgun
   end
 
 end
-
-ActionMailer::Base.add_delivery_method :mailgun, Railgun::Mailer

--- a/lib/railgun/railtie.rb
+++ b/lib/railgun/railtie.rb
@@ -1,0 +1,9 @@
+require 'railgun/mailer'
+
+module Railgun
+  class Railtie < ::Rails::Railtie
+    config.before_configuration do
+      ActionMailer::Base.add_delivery_method :mailgun, Railgun::Mailer
+    end
+  end
+end


### PR DESCRIPTION
This will automatically load the railgun ActionMailer delivery method when Rails is present. It also switches to a Railtie so it will be added at the right point (when ActionMailer is loaded, but before any config is done to avoid missing method errors).

Fixes #80