### PR TITLE
Store mail deliveries in test mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,31 @@ Batch Message is an extension of Message Builder, and allows you to easily send
 a batch message job within a few seconds. The complexity of
 batch messaging is eliminated!
 
+Testing mail deliveries
+----------------------
+
+```ruby
+# First, instantiate the Mailgun Client with your API key
+mg_client = Mailgun::Client.new 'your-api-key'
+
+# Put the client in test mode
+mg_client.enable_test_mode!
+
+# Define your message parameters
+message_params = {  from: 'bob@sending_domain.com',
+                    to: 'sally@example.com',
+                    subject: 'The Ruby SDK is awesome!',
+                    text: 'It is really easy to send a message!'
+                  }
+
+# Send your message through the client
+# Note: This will not actually hit the API, and will return a generic OK response.
+mg_client.send_message('sending_domain.com', message_params)
+
+# You can now access a copy of message_params
+Mailgun::Client.deliveries.first[:from] # => 'bob@sending_domain.com'
+```
+
 Testing
 -------
 

--- a/lib/mailgun/client.rb
+++ b/lib/mailgun/client.rb
@@ -44,6 +44,13 @@ module Mailgun
       @test_mode
     end
 
+    # Provides a store of all the emails sent in test mode so you can check them.
+    #
+    # @return [Hash]
+    def self.deliveries
+      @@deliveries ||= []
+    end
+
     # Simple Message Sending
     #
     # @param [String] working_domain This is the domain you wish to send from.
@@ -52,6 +59,7 @@ module Mailgun
     # @return [Mailgun::Response] A Mailgun::Response object.
     def send_message(working_domain, data)
       if test_mode? then
+        Mailgun::Client.deliveries << data
         return Response.from_hash(
           {
             :body => '{"id": "test-mode-mail@localhost", "message": "Queued. Thank you."}',


### PR DESCRIPTION
Fixes #93 

Also documents `Mailgun::Client#enable_test_mode!`, which was undocumented.