### PR TITLE
Events#previous and Events#next should accept params

### DIFF
--- a/lib/mailgun/events/events.rb
+++ b/lib/mailgun/events/events.rb
@@ -36,18 +36,22 @@ module Mailgun
     # If an events request hasn't been sent previously, this will send one
     #   without parameters
     #
+    # params - a Hash of query options and/or filters.
+    #
     # Returns a Mailgun::Response object.
-    def next
-      get_events(nil, @paging_next)
+    def next(params = nil)
+      get_events(params, @paging_next)
     end
 
     # Public: Using built in paging, obtains the previous set of data.
     # If an events request hasn't been sent previously, this will send one
     #   without parameters
     #
+    # params - a Hash of query options and/or filters.
+    #
     # Returns Mailgun::Response object.
-    def previous
-      get_events(nil, @paging_previous)
+    def previous(params = nil)
+      get_events(params, @paging_previous)
     end
 
     private


### PR DESCRIPTION
Ideas:
+ Maybe `get` should just be an alias for `next`?
+ Make `params` and argument to initialize. This will allow you to make the Events object enumerable.

```ruby
class Events
  include Enumerable

  def each(&block)
    items = self.next.to_h['items']

    until items.empty?
      items.each(&block)
      items = self.next.to_h['items']
    end
  end
end
```