### PR TITLE
don't send multi-part mail if only html or text is provided

### DIFF
--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -135,7 +135,7 @@ module Railgun
   # @return [String]
   def extract_body_html(mail)
     begin
-      (mail.html_part || mail).body.decoded || nil
+      mail.html_part.body.decoded || nil
     rescue
       nil
     end
@@ -149,7 +149,7 @@ module Railgun
   # @return [String]
   def extract_body_text(mail)
     begin
-      (mail.text_part || mail).body.decoded || nil
+      mail.text_part.body.decoded || nil
     rescue
       nil
     end


### PR DESCRIPTION
When a rails app sends only a text mail, then Railgun sends also the html part (converted from the text part).

The problem, is that all newlines are ignored, when the mail is view in an html capable mail client.

e.g. if the text part of a  mail  has two lines
```
first line
second line
````
then it  will be shown as one line  in a mail-client with html support.:

```
first line second line
````
