### PR TITLE
[Docs] fixed Webhooks.md `remove_all` method in docs.

### DIFF
--- a/docs/Webhooks.md
+++ b/docs/Webhooks.md
@@ -31,7 +31,7 @@ hook.create 'my.perfect.domain', 'deliver', 'https://the.webhook.url/'
 hook.remove 'my.perfect.domain', 'deliver'
 
 # Remove all webhooks for a domain
-hook.remove 'my.perfect.domain'
+hook.remove_all 'my.perfect.domain'
 ```
 
 More Documentation


### PR DESCRIPTION
This PR fixes a minor typo in `Webhooks.md` file where remove_all was incorrectly mentioned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mailgun/mailgun-ruby/115)
<!-- Reviewable:end -->
