### PR TITLE
Perform mailbox validation

### DIFF
--- a/lib/mailgun/address.rb
+++ b/lib/mailgun/address.rb
@@ -18,8 +18,11 @@ module Mailgun
     # Given an arbitrary address, validates it based on defined checks.
     #
     # @param [String] address Email address to validate (max 512 chars.)
-    def validate(address)
-      res = @client.get "address/validate", {:address => address}
+    def validate(address, mailbox_verification = false)
+      params = {:address => address}
+      params[:mailbox_verification] = true if mailbox_verification
+
+      res = @client.get "address/validate", params
       return res.to_h!
     end
 

--- a/spec/integration/email_validation_spec.rb
+++ b/spec/integration/email_validation_spec.rb
@@ -38,6 +38,12 @@ describe 'For the email validation endpoint', order: :defined, vcr: vcr_opts do
     expect(res).to eq(expected)
   end
 
+  it 'performs mailbox validation for alice@mailgun.net' do
+    res = @mg_obj.validate("alice@mailgun.net", true)
+
+    expect(res["mailbox_verification"]).to eq("true")
+  end
+
   it 'fails to validate example.org' do
     res = @mg_obj.validate("example.org")
 

--- a/vcr_cassettes/email_validation.yml
+++ b/vcr_cassettes/email_validation.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api:<PUBKEY>@api.mailgun.net/v3/address/parse?addresses=Alice%20%3Calice@example.com%3E%3Bbob@example.com%3Bexample.org&syntax_only=true
+    uri: https://api:<APIKEY>@api.mailgun.net/v3/address/parse?addresses=Alice%20%3Calice@example.com%3E%3Bbob@example.com%3Bexample.org&syntax_only=true
     body:
       encoding: US-ASCII
       string: ''
     headers:
       Accept:
-      - "*/*"
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -33,7 +33,7 @@ http_interactions:
       Content-Disposition:
       - inline
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Max-Age:
       - '600'
       Access-Control-Allow-Methods:
@@ -56,13 +56,13 @@ http_interactions:
   recorded_at: Wed, 26 Oct 2016 22:44:50 GMT
 - request:
     method: get
-    uri: https://api:<PUBKEY>@api.mailgun.net/v3/address/validate?address=alice@mailgun.net
+    uri: https://api:<APIKEY>@api.mailgun.net/v3/address/validate?address=alice@mailgun.net
     body:
       encoding: US-ASCII
       string: ''
     headers:
       Accept:
-      - "*/*"
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -87,7 +87,7 @@ http_interactions:
       Content-Disposition:
       - inline
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Max-Age:
       - '600'
       Access-Control-Allow-Methods:
@@ -111,13 +111,13 @@ http_interactions:
   recorded_at: Wed, 26 Oct 2016 22:44:50 GMT
 - request:
     method: get
-    uri: https://api:<PUBKEY>@api.mailgun.net/v3/address/validate?address=example.org
+    uri: https://api:<APIKEY>@api.mailgun.net/v3/address/validate?address=example.org
     body:
       encoding: US-ASCII
       string: ''
     headers:
       Accept:
-      - "*/*"
+      - '*/*'
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -142,7 +142,7 @@ http_interactions:
       Content-Disposition:
       - inline
       Access-Control-Allow-Origin:
-      - "*"
+      - '*'
       Access-Control-Max-Age:
       - '600'
       Access-Control-Allow-Methods:
@@ -164,4 +164,52 @@ http_interactions:
         }
     http_version: 
   recorded_at: Wed, 26 Oct 2016 22:44:50 GMT
+- request:
+    method: get
+    uri: https://api:<APIKEY>@api.mailgun.net/v3/address/validate?address=alice@mailgun.net&mailbox_verification=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin16.7.0 x86_64) ruby/2.0.0p0
+      Host:
+      - api.mailgun.net
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 12 Sep 2017 16:55:09 GMT
+      Server:
+      - nginx
+      Content-Length:
+      - '243'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address": "alice@mailgun.net", "did_you_mean": null, "is_disposable_address":
+        false, "is_role_address": false, "is_valid": true, "mailbox_verification":
+        "true", "parts": {"display_name": null, "domain": "mailgun.net", "local_part":
+        "alice"}}'
+    http_version: 
+  recorded_at: Tue, 12 Sep 2017 16:55:09 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
Allow mailbox verification when validating addresses by sending the `mailbox_verification` query string param [per the documentation](https://documentation.mailgun.com/en/latest/api-email-validation.html#email-validation).