### PR TITLE
Small/easy to review PR: Allow caller to specify full_name instead of first/last.

### DIFF
--- a/lib/mailgun/messages/message_builder.rb
+++ b/lib/mailgun/messages/message_builder.rb
@@ -379,8 +379,15 @@ module Mailgun
     def parse_address(address, vars)
       return address unless vars.is_a? Hash
       fail(Mailgun::ParameterError, 'Email address not specified') unless address.is_a? String
+      if vars['full_name'] != nil && (vars['first'] != nil || vars['last'] != nil)
+        fail(Mailgun::ParameterError, 'Must specify at most one of full_name or first/last. Vars passed: #{vars}')
+      end
 
-      full_name = "#{vars['first']} #{vars['last']}".strip
+      if vars['full_name']
+        full_name = vars['full_name']
+      elsif vars['first'] || vars['last']
+        full_name = "#{vars['first']} #{vars['last']}".strip
+      end 
 
       return "'#{full_name}' <#{address}>" if defined?(full_name)
       address

--- a/spec/unit/messages/message_builder_spec.rb
+++ b/spec/unit/messages/message_builder_spec.rb
@@ -196,13 +196,28 @@ describe 'The method from' do
     expect(@mb_obj.message[:from]).to eq([the_from_address])
   end
 
-  it 'sets the from address with metadata' do
+  it 'sets the from address with first/last metadata' do
     the_from_address = 'test@mailgun.com'
     the_first_name = 'Magilla'
     the_last_name = 'Gorilla'
     @mb_obj.from(the_from_address, {'first' => the_first_name, 'last' => the_last_name})
 
     expect(@mb_obj.message[:from]).to eq(["'#{the_first_name} #{the_last_name}' <#{the_from_address}>"])
+  end
+
+  it 'sets the from address with full name metadata' do
+    the_from_address = 'test@mailgun.com'
+    full_name = 'Magilla Gorilla'
+    @mb_obj.from(the_from_address, {'full_name' => full_name})
+
+    expect(@mb_obj.message[:from]).to eq(["'#{full_name}' <#{the_from_address}>"])
+  end
+
+  it 'fails when first/last and full_name are used' do
+    the_from_address = 'test@mailgun.com'
+    full_name = 'Magilla Gorilla'
+    first_name = 'Magilla'
+    expect{@mb_obj.from(the_from_address, {'full_name' => full_name, 'first' => first_name})}.to raise_error(Mailgun::ParameterError)
   end
 end
 


### PR DESCRIPTION
In some places in our code base we store senders/recipients with their full name instead of first/last.

Also, seems like it could be useful in cases where sender or recipients don't have first/last names (e.g. sending on behalf of a team).