### PR TITLE
Fix content type

### DIFF
--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -138,7 +138,7 @@ module Railgun
   # @return [String]
   def extract_body_html(mail)
     begin
-      (mail.html_part || mail).body.decoded || nil
+      retrieve_html_part(mail).body.decoded || nil
     rescue
       nil
     end
@@ -152,10 +152,34 @@ module Railgun
   # @return [String]
   def extract_body_text(mail)
     begin
-      (mail.text_part || mail).body.decoded || nil
+      retrieve_text_part(mail).body.decoded || nil
     rescue
       nil
     end
+  end
+
+  # Returns the mail object from the Mail::Message object if text part exists,
+  # (decomposing multipart into individual format if necessary)
+  # otherwise nil.
+  #
+  # @param [Mail::Message] mail message to transform
+  #
+  # @return [Mail::Message] mail message with its content-type = text/plain
+  def retrieve_text_part(mail)
+    return mail.text_part if mail.multipart?
+    (mail.mime_type =~ /^text\/plain$/i) && mail
+  end
+
+  # Returns the mail object from the Mail::Message object if html part exists,
+  # (decomposing multipart into individual format if necessary)
+  # otherwise nil.
+  #
+  # @param [Mail::Message] mail message to transform
+  #
+  # @return [Mail::Message] mail message with its content-type = text/html
+  def retrieve_html_part(mail)
+    return mail.html_part if mail.multipart?
+    (mail.mime_type =~ /^text\/html$/i) && mail
   end
 
 end

--- a/mailgun.gemspec
+++ b/mailgun.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.9'
   spec.add_development_dependency 'vcr', '~> 3.0'
   spec.add_development_dependency 'simplecov', '~> 0.11'
-
+  spec.add_development_dependency "rails"
   spec.add_dependency 'rest-client', '~> 2.0'
 
 end

--- a/spec/unit/railgun_spec.rb
+++ b/spec/unit/railgun_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+require 'mailgun'
+require 'railgun'
+
+describe 'extract_body' do
+
+  let(:text_mail_option) {
+    {
+      from:        'bob@example.com',
+      to:          'sally@example.com',
+      subject:     'RAILGUN TEST SAMPLE',
+      body:         text_content,
+      content_type: 'text/plain',
+    }
+  }
+  let(:text_content) { '[TEST] Hello, world.' }
+
+  let(:html_mail_option) {
+    {
+      from:        'bob@example.com',
+      to:          'sally@example.com',
+      subject:     'RAILGUN TEST SAMPLE',
+      body:         html_content,
+      content_type: 'text/html',
+    }
+  }
+  let(:html_content) { '<h3> [TEST] </h3> <br/> Hello, world!' }
+
+  context 'with <Content-Type: text/plain>' do
+    let(:sample_mail) { Mail.new(text_mail_option) }
+
+    it 'should return body text' do
+      expect(Railgun.extract_body_text(sample_mail)).to eq(text_content)
+    end
+
+    it 'should not return body html' do
+      expect(Railgun.extract_body_html(sample_mail)).to be_nil
+    end
+  end
+
+  context 'with <Content-Type: text/html>' do
+    let(:sample_mail) { Mail.new(html_mail_option) }
+
+    it 'should not return body text' do
+      expect(Railgun.extract_body_text(sample_mail)).to be_nil
+    end
+
+    it 'should return body html' do
+      expect(Railgun.extract_body_html(sample_mail)).to eq(html_content)
+    end
+  end
+
+  context 'with <Content-Type: multipart/alternative>' do
+    let(:text_mail) { Mail.new(text_mail_option) }
+    let(:html_mail) { Mail.new(html_mail_option) }
+
+    before do
+      @sample_mail = Mail::Part.new(content_type: "multipart/alternative")
+      @sample_mail.add_part text_mail
+      @sample_mail.add_part html_mail
+    end
+
+    it 'should return body text' do
+      expect(Railgun.extract_body_text(@sample_mail)).to eq(text_content)
+    end
+
+    it 'should return body html' do
+      expect(Railgun.extract_body_html(@sample_mail)).to eq(html_content)
+    end
+  end
+end


### PR DESCRIPTION
Hello, let me submit PR as per the suggestion made at #130.

### changes

Tweaked current Railgun's module_functions so that it does *not* overwrite the email body when nothing is given.

* related with #130 #106 #128 
* (may have crossed with old PR as well)

### unit test

Also added a decent unit test to highlight the original issue:

When running with the current master, Railgun renders html and text part regardless its original settings.

<img width="674" alt="2017-11-22 20 56 19" src="https://user-images.githubusercontent.com/23026542/33127381-986131b4-cfcb-11e7-89dd-50665199bda0.png">

WIth the branch you should see the test goes all green! (which is how ActionMailer behaves by default)

### a few additional notes..

* When updated, it stops creating multipart emails when you don't have the both templates in place. 

* Another small thing: in order to run railgun on rails, I had to add rails gem (for development environment only).
 Hopefully it makes sense (esp. if you are going to add some railgun tests in the future)
