### PR TITLE
Fix error in Webhooks create method

### DIFF
--- a/lib/mailgun/webhooks/webhooks.rb
+++ b/lib/mailgun/webhooks/webhooks.rb
@@ -46,7 +46,7 @@ module Mailgun
     # Returns a Boolean of whether the webhook was created
     def create(domain, action, url = '')
       res = @client.post("domains/#{domain}/webhooks", id: action, url: url)
-      res.to_h['webhook']['url'] == url && res.to_h[message] == 'Webhook has been created'
+      res.to_h['webhook']['url'] == url && res.to_h['message'] == 'Webhook has been created'
     end
     alias_method :add, :create
     alias_method :add_webhook, :create


### PR DESCRIPTION
Use `'message'` instead of `message`. 