### PR TITLE
Fix pagination problem in Mailgun::Events-api introduced in v1.1.8

### DIFF
--- a/lib/mailgun/events/events.rb
+++ b/lib/mailgun/events/events.rb
@@ -101,7 +101,7 @@ module Mailgun
     # Returns a String of the partial URI if the given url follows the regular API format
     # Returns nil in other cases (e.g. when given nil, or an irrelevant url)
     def extract_endpoint_from(url = nil)
-      URI.parse(url).path[/api.mailgun.net\/v[\d]\/#{@domain}\/events\/(.+)/,1]
+      URI.parse(url).path[/\/v[\d]\/#{@domain}\/events\/(.+)/,1]
     rescue URI::InvalidURIError
       nil
     end

--- a/spec/unit/events/events_spec.rb
+++ b/spec/unit/events/events_spec.rb
@@ -11,6 +11,25 @@ describe 'The method get' do
   end
 end
 
+describe 'Pagination' do
+  it 'should return a proper hash of log data.' do
+    @mg_obj = Mailgun::UnitClient.new('events')
+    events = Mailgun::Events.new(@mg_obj, "samples.mailgun.org")
+    result = events.get()
+
+    json = JSON.parse(result.body)
+    expect(json).to include("paging")
+    expect(json["paging"]).to include("next")
+    expect(json["paging"]).to include{"previous"}
+  end
+
+  it 'should calculate proper next-page url' do
+    events = Mailgun::Events.new(@mg_obj, "samples.mailgun.org")
+    output = events.send(:extract_endpoint_from, '/v3/samples.mailgun.org/events/W3siYiI6ICIyMDE3LTA1LTEwVDIwOjA2OjU0LjU3NiswMDowMCIsICJlIjogIjIwMTctMDUtMDhUMjA6MDY6NTQuNTc3KzAwOjAwIn0sIHsiYiI6ICIyMDE3LTA1LTEwVDIwOjA2OjU0LjU3NiswMDowMCIsICJlIjogIjIwMTctMDUtMDhUMjA6MDY6NTQuNTc3KzAwOjAwIn0sIFsiZiJdLCBudWxsLCBbWyJhY2NvdW50LmlkIiwgIjU4MDUyMTg2NzhmYTE2MTNjNzkwYjUwZiJdLCBbImRvbWFpbi5uYW1lIiwgInNhbmRib3gyOTcwMTUyYWYzZDM0NTU5YmZjN2U3MTcwM2E2Y2YyNC5tYWlsZ3VuLm9yZyJdXSwgMTAwLCBudWxsXQ==')
+
+    expect(output).to eq 'W3siYiI6ICIyMDE3LTA1LTEwVDIwOjA2OjU0LjU3NiswMDowMCIsICJlIjogIjIwMTctMDUtMDhUMjA6MDY6NTQuNTc3KzAwOjAwIn0sIHsiYiI6ICIyMDE3LTA1LTEwVDIwOjA2OjU0LjU3NiswMDowMCIsICJlIjogIjIwMTctMDUtMDhUMjA6MDY6NTQuNTc3KzAwOjAwIn0sIFsiZiJdLCBudWxsLCBbWyJhY2NvdW50LmlkIiwgIjU4MDUyMTg2NzhmYTE2MTNjNzkwYjUwZiJdLCBbImRvbWFpbi5uYW1lIiwgInNhbmRib3gyOTcwMTUyYWYzZDM0NTU5YmZjN2U3MTcwM2E2Y2YyNC5tYWlsZ3VuLm9yZyJdXSwgMTAwLCBudWxsXQ=='
+  end
+end
 
 describe 'The method next' do
   it 'should return the next series of data.' do


### PR DESCRIPTION
As discussed in #124 pagination has been broken as @manuelmeurer pointed out the mistake was introduced in the commit here: https://github.com/mailgun/mailgun-ruby/commit/9ad5cbd95f2570b3a3c681cc1e362c702b84eded#diff-e904dd8e3437a9a9c5e35c6dcb227d30 by @fursich and @pirogoeth.

The method  `#extract_endpoint_from` processes a regex with a path as input, but the regex expects a url, thus the method will always be returning `nil`, and pagination is broken.

This means the Ruby-gem might have been broken since 16 Jun 2017.

My specs are a bit ugly, but I was in a hurry, please fix, or give me input how to fix them.

# To test:

Go to an account with event-activity, modify the `begin`+`end` variables and run the following:

```ruby
require 'csv'
require 'mailgun'
require 'digest'

event_settings = {
  'begin' => Time.parse('2018-05-25 00:01:00 UTC').utc.rfc2822,
  'end'   => Time.parse('2018-05-25 03:00:00 UTC').utc.rfc2822,
  'limit' => 300,
  # 'tags'  => 'production',
  # 'event' => 'delivered',
}

mg_client = Mailgun::Client.new(ENV['api_key'])
mg_events = Mailgun::Events.new(mg_client, "mg.billetto.eu")

recipients = Hash.new(0)
total = 0

while(true)
  # Get me the next page for the next iteration
  retries = 0
  begin
    result = mg_events.next(event_settings)
  rescue Mailgun::CommunicationError
    sleep(5)
    retry if (retries += 1) < 3
  end

  # Break free when there are no more events
  break if result.to_h['items'].size == 0

  result.to_h['items'].each do |item|
    print "."
    recipients[item['recipient']] += 1
    total += 1
  end
  sleep(0.2)
end

recipients = recipients.sort {|a,b| b[1]<=>a[1]}
puts total
```

You will observe that it never breaks out of the while(true) loop because your software will never actually change pages.