### PR TITLE
Minor fix in name require

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Usage
 Here's how to send a message using the library:
 
 ```ruby
-require 'mailgun'
+require 'mailgun-ruby'
 
 # First, instantiate the Mailgun Client with your API key
 mg_client = Mailgun::Client.new 'your-api-key'


### PR DESCRIPTION
I have changed require 'mailgun' by 'mailgun-ruby', not work when only use mailgun.