### PR TITLE
[Railgun] Allow to define tags params on Railgun::Mailer#mail

### DIFF
--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -120,6 +120,8 @@ module Railgun
       end
     end
 
+    mail[:tags].each { |tag| mb.add_tag(tag) } if mail[:tags].present?
+
     return mb.message if mail.attachments.empty?
 
     mail.attachments.each do |attach|


### PR DESCRIPTION
This PR allow the following :

```mail(to: user.email, subject: 'HelloWorld !', tags: ['web', 'user_registered'])```