### PR TITLE
Fix for duplicate reply-to headers

### DIFF
--- a/lib/mailgun/messages/message_builder.rb
+++ b/lib/mailgun/messages/message_builder.rb
@@ -70,7 +70,7 @@ module Mailgun
     # @return [void]
     def reply_to(address, variables = nil)
       compiled_address = parse_address(address, variables)
-      header("reply-to", compiled_address)
+      header("Reply-To", compiled_address)
     end
 
     # Set a subject for the message object
@@ -387,7 +387,7 @@ module Mailgun
         full_name = vars['full_name']
       elsif vars['first'] || vars['last']
         full_name = "#{vars['first']} #{vars['last']}".strip
-      end 
+      end
 
       return "'#{full_name}' <#{address}>" if defined?(full_name)
       address

--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -11,7 +11,7 @@ module Railgun
   class Mailer
 
     # List of the headers that will be ignored when copying headers from `mail.header_fields`
-    IGNORED_HEADERS = %w[ to from subject ]
+    IGNORED_HEADERS = %w[ to from subject reply-to ]
 
     # [Hash] config ->
     #   Requires *at least* `api_key` and `domain` keys.

--- a/spec/unit/messages/message_builder_spec.rb
+++ b/spec/unit/messages/message_builder_spec.rb
@@ -66,11 +66,11 @@ describe 'The method add_recipient' do
     expect(@mb_obj.counters[:recipients][recipient_type]).to eq(1)
   end
 
-  it 'adds a "h:reply-to" recipient type to the message body and counters are not incremented' do
-    recipient_type = 'h:reply-to'
+  it 'adds a "h:Reply-To" recipient type to the message body and counters are not incremented' do
+    recipient_type = 'h:Reply-To'
     @mb_obj.add_recipient(recipient_type, @address, @variables)
 
-    expect(@mb_obj.message[recipient_type]).to eq("'#{@variables['first']} #{@variables['last']}' <#{@address}>")
+    expect(@mb_obj.message[recipient_type][0]).to eq("'#{@variables['first']} #{@variables['last']}' <#{@address}>")
     @mb_obj.counters[:recipients].each_value{|value| expect(value).to eq(0)}
   end
 

--- a/spec/unit/railgun/mailer_spec.rb
+++ b/spec/unit/railgun/mailer_spec.rb
@@ -112,6 +112,18 @@ describe 'Railgun::Mailer' do
     expect(body['h:X-Unit-Test-2']).to eq('true')
   end
 
+  it 'does not add the reply-to header twice' do
+    message = UnitTestMailer.plain_message('test@example.org', '', {
+      'Reply-To' => 'only@once.com',
+    })
+
+    body = Railgun.transform_for_mailgun(message)
+
+    expect(body).to include('h:Reply-To')
+    expect(body).to_not include('h:reply-to')
+    expect(body['h:Reply-To']).to eq('only@once.com')
+  end
+
   it 'properly handles headers that are passed as separate POST params' do
     message = UnitTestMailer.plain_message('test@example.org', 'Test!', {
       # `From`, `To`, and `Subject` are set on the envelope, so they should be ignored as headers


### PR DESCRIPTION
There is a bug in `Railgun` where `build_message_object` would add the `h:reply-to` header, and where `transform_for_mailgun` would also add the `h:Reply-To` header.

This commit makes sure that `transform_for_mailgun` does not add the `h:Reply-To` header again, and this commit changes `reply_to=` in `MessageBuilder` to use the capitalized header (`h:Reply-To`).