### PR TITLE
Add #template to message_builder

### DIFF
--- a/lib/mailgun/messages/message_builder.rb
+++ b/lib/mailgun/messages/message_builder.rb
@@ -260,6 +260,18 @@ module Mailgun
       header name, data
     end
 
+    # Send email by a template. Note that this is NOT used for template variables, but
+    # rather for the Templating feature (check Sending->Templates)
+    #
+    # @param [String] tag A defined template name to use. Passing nil or
+    #   empty string will delete template key and value from @message hash.
+    # @return [void]
+    def template(template_name = nil)
+      key = 'template'
+      return @message.delete(key) if template_name.to_s.empty?
+      set_single(key, template_name)
+    end
+
     # Attaches custom JSON data to the message. See the following doc page for more info.
     # https://documentation.mailgun.com/user_manual.html#attaching-data-to-messages
     #

--- a/spec/unit/messages/message_builder_spec.rb
+++ b/spec/unit/messages/message_builder_spec.rb
@@ -530,6 +530,34 @@ describe 'The method header' do
   end
 end
 
+describe 'The method template' do
+  before(:each) do
+    @mb_obj = Mailgun::MessageBuilder.new
+  end
+
+  it 'unsets the message template if called and no parameters are provided' do
+    @mb_obj.template
+
+    expect(@mb_obj.message['template']).to be_empty
+  end
+
+  it 'sets the message template if called with the template_name parameter' do
+    template_name = 'template.test'
+    @mb_obj.template(template_name)
+
+    expect(@mb_obj.message['template']).to eq(template_name)
+  end
+
+  it 'ensures no duplicate templates can exist and last setter is stored' do
+    first_template_name = 'template.test'
+    second_template_name = 'template.second_test'
+    @mb_obj.template(first_template_name)
+    @mb_obj.template(second_template_name)
+
+    expect(@mb_obj.message['template']).to eq(second_template_name)
+  end
+end
+
 describe 'The method variable' do
   before(:each) do
     @mb_obj = Mailgun::MessageBuilder.new


### PR DESCRIPTION
# Why
Have been experimenting with Mailgun's Templates feature and realised it is not part of the message builder

# Description

There exists a `header(name, data)` function but inspecting the [source](https://github.com/mailgun/mailgun-ruby/blob/master/lib/mailgun/messages/message_builder.rb) shows that it prepends `h:` to the header key. The template header key must exist without that `h:` prefix as shown in the [documentation](https://documentation.mailgun.com/en/latest/api-templates.html#templates).


Possibly partially addresses #166 