### PR TITLE
Force Travis to use bundler < 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ rvm:
 - 2.3.7
 - 2.4.4
 - 2.5.1
+before_install:
+  - gem install bundler -v '< 2' --conservative
 script:
 - bundle install
 - bundle exec rake spec


### PR DESCRIPTION
# Why

Seems that Travis is failing recent PRs. Inspecting the logs show an issue with Bundler being too new.