### PR TITLE
Add `api_host` option to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ and replace `api-myapikey` and `mydomain.com` with your secret API key and domai
   config.action_mailer.mailgun_settings = {
     api_key: 'api-myapikey',
     domain: 'mydomain.com',
+    api_host: 'api.eu.mailgun.net' # this option is needed only if your domain is set to EU region.
   }
 ```
 


### PR DESCRIPTION
To simplify the integration with EU domains