### PR TITLE
Include config info in README for EU domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ and replace `api-myapikey` and `mydomain.com` with your secret API key and domai
   config.action_mailer.mailgun_settings = {
     api_key: 'api-myapikey',
     domain: 'mydomain.com',
+    # api_host: 'api.eu.mailgun.net'  # Uncomment this line for EU region domains
   }
 ```
 


### PR DESCRIPTION
I struggled for about an hour before realising my domain was configured in `eu`. This extra info in the readme should help others.

NB. This pull request should also close https://github.com/mailgun/mailgun-ruby/pull/163