### PR TITLE
Depend on the RestClient default timeout for network timeouts

### DIFF
--- a/lib/mailgun/client.rb
+++ b/lib/mailgun/client.rb
@@ -17,12 +17,15 @@ module Mailgun
                    test_mode = false,
                    timeout = nil)
 
+      rest_client_params = {
+        user: 'api',
+        password: api_key,
+        user_agent: "mailgun-sdk-ruby/#{Mailgun::VERSION}"
+      }
+      rest_client_params[:timeout] = timeout if timeout
+
       endpoint = endpoint_generator(api_host, api_version, ssl)
-      @http_client = RestClient::Resource.new(endpoint,
-                                              user: 'api',
-                                              password: api_key,
-                                              user_agent: "mailgun-sdk-ruby/#{Mailgun::VERSION}",
-                                              timeout: timeout)
+      @http_client = RestClient::Resource.new(endpoint, rest_client_params)
       @test_mode = test_mode
     end
 


### PR DESCRIPTION
If we pass a `timeout: nil` parameter to `RestClient::Resource.new`, that indicates no timeout. (Wait forever.)

Instead, rely on the default timeout if no timeout is specified.

fixes mailgun/mailgun-ruby#183