### PR TITLE
Fixes batch adding unsubscribes (Issue #150)

### DIFF
--- a/lib/mailgun/suppressions.rb
+++ b/lib/mailgun/suppressions.rb
@@ -157,7 +157,10 @@ module Mailgun
 
         unsubscribe.each do |k, v|
           # Hash values MUST be strings.
-          if not v.is_a? String then
+          # However, unsubscribes contain an array of tags
+          if v.is_a? Array
+            unsubscribe[k] = v.map(&:to_s)
+          elsif !v.is_a? String
             unsubscribe[k] = v.to_s
           end
         end

--- a/spec/integration/suppressions_spec.rb
+++ b/spec/integration/suppressions_spec.rb
@@ -52,12 +52,29 @@ describe 'For the suppressions handling class', order: :defined, vcr: vcr_opts d
     end
   end
 
-  it 'can batch-add unsubscribes' do
+  it 'can batch-add unsubscribes with tags as string' do
     unsubscribes = []
     @addresses.each do |addr|
       unsubscribes.push({
         :address => addr,
         :tag => 'integration',
+      })
+    end
+
+    response, nested = @suppress.create_unsubscribes unsubscribes
+    response.to_h!
+
+    expect(response.code).to eq(200)
+    expect(response.body['message']).to eq('4 addresses have been added to the unsubscribes table')
+    expect(nested.length).to eq(0)
+  end
+
+  it 'can batch-add unsubscribes with tags as array' do
+    unsubscribes = []
+    @addresses.each do |addr|
+      unsubscribes.push({
+        :address => addr,
+        :tags => ['integration'],
       })
     end
 
@@ -123,4 +140,3 @@ describe 'For the suppressions handling class', order: :defined, vcr: vcr_opts d
 
   # TODO: Add tests for pagination support.
 end
-

--- a/vcr_cassettes/bounces.yml
+++ b/vcr_cassettes/bounces.yml
@@ -172,4 +172,208 @@ http_interactions:
         address has been removed"}'
     http_version: 
   recorded_at: Fri, 08 Jan 2016 20:33:30 GMT
-recorded_with: VCR 3.0.1
+- request:
+    method: post
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/bounces
+    body:
+      encoding: UTF-8
+      string: address=integration-test-email%40DOMAIN.TEST&code=550&error=Integration+Test
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Length:
+      - '86'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:50:58 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '115'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"integration-test-email@DOMAIN.TEST","message":"Address
+        has been added to the bounces table"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:50:58 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/bounces/integration-test-email@DOMAIN.TEST
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:50:58 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '201'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"integration-test-email@DOMAIN.TEST","code":"550","error":"Integration
+        Test","created_at":"Mon, 03 Feb 2020 19:50:58 UTC","MessageHash":"4e7b5c06763fbd18060548d8b18687e492b255a7"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:50:58 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/bounces
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:00 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '677'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"items":[{"address":"integration-test-email@DOMAIN.TEST","code":"550","error":"Integration
+        Test","created_at":"Mon, 03 Feb 2020 19:50:58 UTC","MessageHash":"4e7b5c06763fbd18060548d8b18687e492b255a7"}],"paging":{"first":"https://api.mailgun.net/v3/DOMAIN.TEST/bounces?limit=100","last":"https://api.mailgun.net/v3/DOMAIN.TEST/bounces?page=last&limit=100","next":"https://api.mailgun.net/v3/DOMAIN.TEST/bounces?page=next&address=integration-test-email%40DOMAIN.TEST&limit=100","previous":"https://api.mailgun.net/v3/DOMAIN.TEST/bounces?page=previous&address=integration-test-email%40DOMAIN.TEST&limit=100"}}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:00 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/bounces/integration-test-email@DOMAIN.TEST
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:00 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '104'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"integration-test-email@DOMAIN.TEST","message":"Bounced
+        address has been removed"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:00 GMT
+recorded_with: VCR 3.0.3

--- a/vcr_cassettes/complaints.yml
+++ b/vcr_cassettes/complaints.yml
@@ -172,4 +172,208 @@ http_interactions:
         has been removed"}'
     http_version: 
   recorded_at: Fri, 08 Jan 2016 20:32:00 GMT
-recorded_with: VCR 3.0.1
+- request:
+    method: post
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/complaints
+    body:
+      encoding: UTF-8
+      string: address=integration-test-email%40DOMAIN.TEST
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Length:
+      - '54'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:00 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '118'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"integration-test-email@DOMAIN.TEST","message":"Address
+        has been added to the complaints table"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:00 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/complaints/integration-test-email@DOMAIN.TEST
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:01 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '104'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"integration-test-email@DOMAIN.TEST","created_at":"Mon,
+        03 Feb 2020 19:51:00 UTC"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:01 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/complaints
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:03 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '592'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"items":[{"address":"integration-test-email@DOMAIN.TEST","created_at":"Mon,
+        03 Feb 2020 19:51:00 UTC"}],"paging":{"first":"https://api.mailgun.net/v3/DOMAIN.TEST/complaints?limit=100","last":"https://api.mailgun.net/v3/DOMAIN.TEST/complaints?page=last&limit=100","next":"https://api.mailgun.net/v3/DOMAIN.TEST/complaints?page=next&address=integration-test-email%40DOMAIN.TEST&limit=100","previous":"https://api.mailgun.net/v3/DOMAIN.TEST/complaints?page=previous&address=integration-test-email%40DOMAIN.TEST&limit=100"}}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:03 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/complaints/integration-test-email@DOMAIN.TEST
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:03 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '103'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"integration-test-email@DOMAIN.TEST","message":"Spam complaint
+        has been removed"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:03 GMT
+recorded_with: VCR 3.0.3

--- a/vcr_cassettes/domains.yml
+++ b/vcr_cassettes/domains.yml
@@ -357,4 +357,386 @@ http_interactions:
         }
     http_version: 
   recorded_at: Fri, 15 Jan 2016 20:12:54 GMT
-recorded_with: VCR 3.0.1
+- request:
+    method: post
+    uri: https://api.mailgun.net/v3/domains
+    body:
+      encoding: UTF-8
+      string: smtp_password=super_secret&spam_action=tag&wildcard=false&name=integration-test.domain.invalid
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Length:
+      - '94'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:05 GMT
+      Server:
+      - nginx
+      Content-Length:
+      - '54'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "message": "smtp_password cannot be set anymore"
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:05 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/domains/integration-test.domain.invalid
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:05 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '1556'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "domain": {
+            "created_at": "Mon, 03 Feb 2020 19:51:03 GMT",
+            "id": "5e3879a742f836ed26b5d77f",
+            "is_disabled": false,
+            "name": "integration-test.domain.invalid",
+            "require_tls": false,
+            "skip_verification": false,
+            "smtp_login": "postmaster@integration-test.domain.invalid",
+            "spam_action": "tag",
+            "state": "unverified",
+            "type": "custom",
+            "web_prefix": "email",
+            "web_scheme": "http",
+            "wildcard": false
+          },
+          "receiving_dns_records": [
+            {
+              "cached": [],
+              "priority": "10",
+              "record_type": "MX",
+              "valid": "unknown",
+              "value": "mxa.mailgun.org"
+            },
+            {
+              "cached": [],
+              "priority": "10",
+              "record_type": "MX",
+              "valid": "unknown",
+              "value": "mxb.mailgun.org"
+            }
+          ],
+          "sending_dns_records": [
+            {
+              "cached": [],
+              "name": "integration-test.domain.invalid",
+              "record_type": "TXT",
+              "valid": "unknown",
+              "value": "v=spf1 include:mailgun.org ~all"
+            },
+            {
+              "cached": [],
+              "name": "mx._domainkey.integration-test.domain.invalid",
+              "record_type": "TXT",
+              "valid": "unknown",
+              "value": "k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDjO/ThNYWtAnXDnQrFITB34aAD2ipv21UIGn3MiFQ5Kjh4EbbhWd+yBMCuqF/xgroARHQnsn2Xet+nW2y/c2tqZ50aIuSqwZ19rdc0/BtsuK6LXjvKuHzabJ/zsPCN0Wymo/sYry2XPn4xtYxX8j95Obm/hPDXWTRyVJLhsJ+H9QIDAQAB"
+            },
+            {
+              "cached": [],
+              "name": "email.integration-test.domain.invalid",
+              "record_type": "CNAME",
+              "valid": "unknown",
+              "value": "mailgun.org"
+            }
+          ]
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:05 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/domains
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:06 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '4144'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "items": [
+            {
+              "created_at": "Mon, 03 Feb 2020 19:51:03 GMT",
+              "id": "5e3879a742f836ed26b5d77f",
+              "is_disabled": false,
+              "name": "integration-test.domain.invalid",
+              "require_tls": false,
+              "skip_verification": false,
+              "smtp_login": "postmaster@integration-test.domain.invalid",
+              "spam_action": "tag",
+              "state": "unverified",
+              "type": "custom",
+              "web_prefix": "email",
+              "web_scheme": "http",
+              "wildcard": false
+            },
+            {
+              "created_at": "Tue, 21 Jan 2020 16:34:29 GMT",
+              "id": "5e2728156556d579c1a79fe4",
+              "is_disabled": false,
+              "name": "opera.mail.epifany.com",
+              "require_tls": false,
+              "skip_verification": false,
+              "smtp_login": "postmaster@opera.mail.epifany.com",
+              "smtp_password": "16dc011fc19e7697cca7e11fd3f66c91-9dfbeecd-d3964b03",
+              "spam_action": "disabled",
+              "state": "active",
+              "type": "custom",
+              "web_prefix": "email",
+              "web_scheme": "http",
+              "wildcard": false
+            },
+            {
+              "created_at": "Tue, 16 Jul 2019 19:03:05 GMT",
+              "id": "5d2e1f695c4c97f60d603995",
+              "is_disabled": false,
+              "name": "o2.mail.epifany.com",
+              "require_tls": false,
+              "skip_verification": false,
+              "smtp_login": "postmaster@o2.mail.epifany.com",
+              "smtp_password": "022108938e7e6509f16cfadeed322ccd-fd0269a6-9c3b21f6",
+              "spam_action": "disabled",
+              "state": "active",
+              "type": "custom",
+              "web_prefix": "email",
+              "web_scheme": "http",
+              "wildcard": false
+            },
+            {
+              "created_at": "Wed, 13 Feb 2019 15:48:52 GMT",
+              "id": "5c643c64d0303a00013fa393",
+              "is_disabled": false,
+              "name": "mail.epifany.com",
+              "require_tls": false,
+              "skip_verification": false,
+              "smtp_login": "postmaster@mail.epifany.com",
+              "smtp_password": "7fe8d976f40571f03a7cc900e2008ac7-1b65790d-7f23d5a8",
+              "spam_action": "disabled",
+              "state": "active",
+              "type": "custom",
+              "web_prefix": "email",
+              "web_scheme": "http",
+              "wildcard": false
+            },
+            {
+              "created_at": "Thu, 17 Jan 2019 15:38:27 GMT",
+              "id": "5c40a173d0303a000171a861",
+              "is_disabled": false,
+              "name": "DOMAIN.TEST",
+              "require_tls": false,
+              "skip_verification": false,
+              "smtp_login": "postmaster@DOMAIN.TEST",
+              "smtp_password": "4ed55266b26401a49222a5ab6824485f-3939b93a-10914bde",
+              "spam_action": "disabled",
+              "state": "active",
+              "type": "custom",
+              "web_prefix": "email",
+              "web_scheme": "http",
+              "wildcard": false
+            },
+            {
+              "created_at": "Fri, 02 Dec 2016 02:26:46 GMT",
+              "id": "5840dbe6354c785e6e6c9e2f",
+              "is_disabled": false,
+              "name": "mailgun.getstealz.com",
+              "require_tls": false,
+              "skip_verification": false,
+              "smtp_login": "postmaster@mailgun.getstealz.com",
+              "smtp_password": "fd33b34bb8549093c76dd6a3157831c7",
+              "spam_action": "disabled",
+              "state": "active",
+              "type": "custom",
+              "web_prefix": "email",
+              "web_scheme": "http",
+              "wildcard": false
+            },
+            {
+              "created_at": "Fri, 26 Sep 2014 16:59:34 GMT",
+              "id": "54259b76045ca43d0ae247e4",
+              "is_disabled": false,
+              "name": "members.getstealz.com",
+              "require_tls": false,
+              "skip_verification": false,
+              "smtp_login": "postmaster@members.getstealz.com",
+              "smtp_password": "1a8f49fbc33bdfd7d47199b2d5100bbe",
+              "spam_action": "disabled",
+              "state": "active",
+              "type": "custom",
+              "web_prefix": "email",
+              "web_scheme": "http",
+              "wildcard": false
+            },
+            {
+              "created_at": "Wed, 12 Sep 2012 13:18:02 GMT",
+              "id": "50508b8a69d7c533fe012a2b",
+              "is_disabled": false,
+              "name": "getstealz.mailgun.org",
+              "require_tls": false,
+              "skip_verification": false,
+              "smtp_login": "postmaster@getstealz.mailgun.org",
+              "smtp_password": "3qih3vfvclh8",
+              "spam_action": "disabled",
+              "state": "active",
+              "type": "sandbox",
+              "web_prefix": "email",
+              "web_scheme": "http",
+              "wildcard": false
+            }
+          ],
+          "total_count": 8
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:06 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/domains/integration-test.domain.invalid
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:06 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '42'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "message": "Domain has been deleted"
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:06 GMT
+recorded_with: VCR 3.0.3

--- a/vcr_cassettes/email_validation.yml
+++ b/vcr_cassettes/email_validation.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*'
+      - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -33,7 +33,7 @@ http_interactions:
       Content-Disposition:
       - inline
       Access-Control-Allow-Origin:
-      - '*'
+      - "*"
       Access-Control-Max-Age:
       - '600'
       Access-Control-Allow-Methods:
@@ -62,7 +62,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*'
+      - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -87,7 +87,7 @@ http_interactions:
       Content-Disposition:
       - inline
       Access-Control-Allow-Origin:
-      - '*'
+      - "*"
       Access-Control-Max-Age:
       - '600'
       Access-Control-Allow-Methods:
@@ -117,7 +117,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*'
+      - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -142,7 +142,7 @@ http_interactions:
       Content-Disposition:
       - inline
       Access-Control-Allow-Origin:
-      - '*'
+      - "*"
       Access-Control-Max-Age:
       - '600'
       Access-Control-Allow-Methods:
@@ -172,7 +172,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*'
+      - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -189,7 +189,7 @@ http_interactions:
       Access-Control-Allow-Methods:
       - GET, POST, PUT, DELETE, OPTIONS
       Access-Control-Allow-Origin:
-      - '*'
+      - "*"
       Access-Control-Max-Age:
       - '600'
       Content-Disposition:
@@ -212,4 +212,160 @@ http_interactions:
         "alice"}}'
     http_version: 
   recorded_at: Tue, 12 Sep 2017 16:55:09 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/address/parse?addresses=Alice%20%3Calice@example.com%3E%3Bbob@example.com%3Bexample.org&syntax_only=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOjxNQUlMR1VOX1BVQkxJQ19BUElLRVk+
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:07 GMT
+      Server:
+      - nginx
+      Www-Authenticate:
+      - Basic realm="MG API"
+      Content-Length:
+      - '32'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"message":"Invalid public key"}'
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:07 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/address/validate?address=alice@mailgun.net
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOjxNQUlMR1VOX1BVQkxJQ19BUElLRVk+
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:07 GMT
+      Server:
+      - nginx
+      Www-Authenticate:
+      - Basic realm="MG API"
+      Content-Length:
+      - '32'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"message":"Invalid public key"}'
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:07 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/address/validate?address=alice@mailgun.net&mailbox_verification=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOjxNQUlMR1VOX1BVQkxJQ19BUElLRVk+
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:07 GMT
+      Server:
+      - nginx
+      Www-Authenticate:
+      - Basic realm="MG API"
+      Content-Length:
+      - '32'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"message":"Invalid public key"}'
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:07 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/address/validate?address=example.org
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOjxNQUlMR1VOX1BVQkxJQ19BUElLRVk+
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:07 GMT
+      Server:
+      - nginx
+      Www-Authenticate:
+      - Basic realm="MG API"
+      Content-Length:
+      - '32'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"message":"Invalid public key"}'
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:08 GMT
 recorded_with: VCR 3.0.3

--- a/vcr_cassettes/events.yml
+++ b/vcr_cassettes/events.yml
@@ -105,4 +105,3997 @@ http_interactions:
         \ }\n}"
     http_version: 
   recorded_at: Wed, 10 May 2017 20:06:54 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/events?limit=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:08 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '2703'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "items": [
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579864823.863905,
+              "log-level": "info",
+              "id": "btQxTjeKRQWTp3J2v4lMcg",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "ip": "99.85.27.49",
+              "client-info": {
+                "client-os": "iOS",
+                "device-type": "mobile",
+                "client-name": "Mobile Safari",
+                "client-type": "mobile browser",
+                "user-agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 13_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd19a012_42b2a4e1f6bcc9752f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "opened"
+            }
+          ],
+          "paging": {
+            "previous": "https://api.mailgun.net/v3/DOMAIN.TEST/events/WzMseyJiIjoiMjAyMC0wMi0wM1QxOTo1MTowOC4xNjcrMDA6MDAiLCJlIjoiMjAyMC0wMS0wNFQxOTo1MTowOC4xNjcrMDA6MDAifSx7ImIiOiIyMDIwLTAxLTI0VDExOjIwOjIzLjg2MyswMDowMCIsImUiOiIyMDIwLTAyLTAzVDE5OjUxOjA4LjE2OCswMDowMCJ9LCJfZG9jI2J0UXhUamVLUlFXVHAzSjJ2NGxNY2ciLFsicCIsImYiXSxudWxsLFtbImFjY291bnQuaWQiLCI1MDUwOGI4OTY5ZDdjNTMzZmUwMTJhMjgiXSxbImRvbWFpbi5uYW1lIiwidGVzdC1tYWlsLmVwaWZhbnkuY29tIl1dLDFd",
+            "first": "https://api.mailgun.net/v3/DOMAIN.TEST/events/WzMseyJiIjoiMjAyMC0wMi0wM1QxOTo1MTowOC4xNjcrMDA6MDAiLCJlIjoiMjAyMC0wMS0wNFQxOTo1MTowOC4xNjcrMDA6MDAifSx7ImIiOiIyMDIwLTAyLTAzVDE5OjUxOjA4LjE2NyswMDowMCIsImUiOiIyMDIwLTAxLTA0VDE5OjUxOjA4LjE2NyswMDowMCJ9LG51bGwsWyJmIl0sbnVsbCxbWyJhY2NvdW50LmlkIiwiNTA1MDhiODk2OWQ3YzUzM2ZlMDEyYTI4Il0sWyJkb21haW4ubmFtZSIsInRlc3QtbWFpbC5lcGlmYW55LmNvbSJdXSwxXQ==",
+            "last": "https://api.mailgun.net/v3/DOMAIN.TEST/events/WzMseyJiIjoiMjAyMC0wMi0wM1QxOTo1MTowOC4xNjcrMDA6MDAiLCJlIjoiMjAyMC0wMS0wNFQxOTo1MTowOC4xNjcrMDA6MDAifSx7ImIiOiIyMDIwLTAxLTA0VDE5OjUxOjA4LjE2NyswMDowMCIsImUiOiIyMDIwLTAyLTAzVDE5OjUxOjA4LjE2NyswMDowMCJ9LG51bGwsWyJwIiwiZiJdLG51bGwsW1siYWNjb3VudC5pZCIsIjUwNTA4Yjg5NjlkN2M1MzNmZTAxMmEyOCJdLFsiZG9tYWluLm5hbWUiLCJ0ZXN0LW1haWwuZXBpZmFueS5jb20iXV0sMV0=",
+            "next": "https://api.mailgun.net/v3/DOMAIN.TEST/events/WzMseyJiIjoiMjAyMC0wMi0wM1QxOTo1MTowOC4xNjcrMDA6MDAiLCJlIjoiMjAyMC0wMS0wNFQxOTo1MTowOC4xNjcrMDA6MDAifSx7ImIiOiIyMDIwLTAxLTI0VDExOjIwOjIzLjg2MyswMDowMCIsImUiOiIyMDIwLTAxLTA0VDE5OjUxOjA4LjE2NyswMDowMCJ9LCJfZG9jI2J0UXhUamVLUlFXVHAzSjJ2NGxNY2ciLFsiZiJdLG51bGwsW1siYWNjb3VudC5pZCIsIjUwNTA4Yjg5NjlkN2M1MzNmZTAxMmEyOCJdLFsiZG9tYWluLm5hbWUiLCJ0ZXN0LW1haWwuZXBpZmFueS5jb20iXV0sMV0="
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:08 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/events
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:08 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "items": [
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579864823.863905,
+              "log-level": "info",
+              "id": "btQxTjeKRQWTp3J2v4lMcg",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "ip": "99.85.27.49",
+              "client-info": {
+                "client-os": "iOS",
+                "device-type": "mobile",
+                "client-name": "Mobile Safari",
+                "client-type": "mobile browser",
+                "user-agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 13_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd19a012_42b2a4e1f6bcc9752f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "66.102.8.2",
+              "recipient-domain": "epifany.com",
+              "id": "vYerPHQuRnKMLF2j0yWYMw",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579836856.5557,
+              "client-info": {
+                "client-type": "browser",
+                "device-type": "desktop",
+                "client-name": "Firefox",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd298eff_42b2a4e1f6bcc976c0@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=julie.barberio%40epifany.com&type=default",
+              "ip": "99.85.27.49",
+              "log-level": "info",
+              "id": "NsmNZwnWSf67Kcy2W7n1KQ",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579807617.50862,
+              "client-info": {
+                "client-type": "browser",
+                "client-os": "OS X",
+                "device-type": "desktop",
+                "client-name": "Chrome",
+                "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd19a012_42b2a4e1f6bcc9752f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "66.249.88.82",
+              "recipient-domain": "epifany.com",
+              "id": "_mS5k6QKSq6no0wftddz6Q",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579807605.29194,
+              "client-info": {
+                "client-type": "browser",
+                "device-type": "desktop",
+                "client-name": "Firefox",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd19a012_42b2a4e1f6bcc9752f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=julie.barberio%40epifany.com&type=default",
+              "timestamp": 1579807382.704875,
+              "log-level": "info",
+              "id": "dy6QfYa3RqS4U8u6vgjeLA",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "ip": "99.85.27.49",
+              "client-info": {
+                "client-os": "iOS",
+                "device-type": "mobile",
+                "client-name": "Mobile Safari",
+                "client-type": "mobile browser",
+                "user-agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 13_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.4 Mobile/15E148 Safari/604.1"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd19a012_42b2a4e1f6bcc9752f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "99.85.27.49",
+              "recipient-domain": "epifany.com",
+              "id": "jFjXXbWHQ9upHUksbtD5Nw",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579807379.659872,
+              "client-info": {
+                "client-type": "mobile browser",
+                "device-type": "mobile",
+                "client-name": "Mobile Safari",
+                "user-agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 13_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+                "client-os": "iOS"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd19a012_42b2a4e1f6bcc9752f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=julie.barberio%40epifany.com&type=default",
+              "timestamp": 1579807340.308709,
+              "log-level": "info",
+              "id": "_WVT-udDTvmKCgD1mOq9oQ",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "ip": "99.85.27.49",
+              "client-info": {
+                "client-os": "iOS",
+                "device-type": "mobile",
+                "client-name": "Mobile Safari",
+                "client-type": "mobile browser",
+                "user-agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 13_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.4 Mobile/15E148 Safari/604.1"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd19a012_42b2a4e1f6bcc9752f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=julie.barberio%40epifany.com&type=default",
+              "ip": "66.102.8.12",
+              "recipient-domain": "epifany.com",
+              "id": "mRoDnz8NSJqZG4mjSUWchQ",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579807083.472949,
+              "client-info": {
+                "client-name": "Chrome",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
+                "device-type": "desktop",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd19a012_42b2a4e1f6bcc9752f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=julie.barberio%40epifany.com&type=default",
+              "ip": "66.102.8.30",
+              "recipient-domain": "epifany.com",
+              "id": "pKGcSv4QQNaUcnsNiEpR1w",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579807083.144508,
+              "client-info": {
+                "client-type": "browser",
+                "device-type": "desktop",
+                "client-name": "Chrome",
+                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd19a012_42b2a4e1f6bcc9752f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=julie.barberio%40epifany.com&type=default",
+              "ip": "99.85.27.49",
+              "recipient-domain": "epifany.com",
+              "id": "nWnbXAtGTBicy1ZKBuAo1w",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579807080.211726,
+              "client-info": {
+                "client-type": "browser",
+                "device-type": "desktop",
+                "client-name": "Chrome",
+                "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36",
+                "client-os": "OS X"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd19a012_42b2a4e1f6bcc9752f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "66.102.7.110",
+              "log-level": "info",
+              "id": "1QKAlc3YSCaErJvOs_jxYQ",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579807077.276399,
+              "client-info": {
+                "client-type": "browser",
+                "client-os": "Windows",
+                "device-type": "desktop",
+                "client-name": "Firefox",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd19a012_42b2a4e1f6bcc9752f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "99.85.27.49",
+              "recipient-domain": "epifany.com",
+              "id": "cImcCNCUTDuRwk5OtZG_Ug",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579806790.390552,
+              "client-info": {
+                "client-name": "Mobile Safari",
+                "client-type": "mobile browser",
+                "user-agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 13_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+                "device-type": "mobile",
+                "client-os": "iOS"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd19a012_42b2a4e1f6bcc9752f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Mountain View",
+                "region": "CA",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=haley.rafols%40epifany.com&type=default",
+              "timestamp": 1579805862.243044,
+              "log-level": "info",
+              "id": "QhbGuGl1Qu2XpaRMgQAlzQ",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "ip": "66.249.92.5",
+              "client-info": {
+                "client-os": "Windows",
+                "device-type": "desktop",
+                "client-name": "Chrome",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246 Mozilla/5.0"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfcf52157_42b2a4e1f6bcc9733f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=amanda.powell%40epifany.com&type=default",
+              "ip": "199.255.11.3",
+              "log-level": "info",
+              "id": "t07hvVnvToe9BWaZeOrT6A",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579799886.543381,
+              "client-info": {
+                "client-type": "browser",
+                "client-os": "OS X",
+                "device-type": "desktop",
+                "client-name": "Chrome",
+                "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd049110_42b2a4e1f6bcc974fc@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=amanda.powell%40epifany.com&type=default",
+              "ip": "199.255.11.3",
+              "log-level": "info",
+              "id": "Bhtjsod5RWCITU15XTSKWQ",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579799805.919598,
+              "client-info": {
+                "client-type": "browser",
+                "client-os": "OS X",
+                "device-type": "desktop",
+                "client-name": "Chrome",
+                "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd049110_42b2a4e1f6bcc974fc@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=amanda.powell%40epifany.com&type=default",
+              "ip": "199.255.11.3",
+              "log-level": "info",
+              "id": "AWZrjmCbQ2aAbpfV8TzUqg",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579799798.693114,
+              "client-info": {
+                "client-type": "browser",
+                "client-os": "OS X",
+                "device-type": "desktop",
+                "client-name": "Chrome",
+                "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd049110_42b2a4e1f6bcc974fc@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579799797.480009,
+              "log-level": "info",
+              "id": "slNja1hlTpu4EPAMZo91FQ",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "ip": "66.249.88.83",
+              "client-info": {
+                "client-os": "Windows",
+                "device-type": "desktop",
+                "client-name": "Firefox",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd049110_42b2a4e1f6bcc974fc@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=haley.rafols%40epifany.com&type=default",
+              "ip": "199.255.11.3",
+              "log-level": "info",
+              "id": "cbcfTEz1QBmncB8gyDU3pA",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579798801.271788,
+              "client-info": {
+                "client-type": "mobile browser",
+                "client-os": "iOS",
+                "device-type": "mobile",
+                "client-name": "Mobile Safari",
+                "user-agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.1 Mobile/15E148 Safari/604.1"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfcf52157_42b2a4e1f6bcc9733f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=amanda.powell%40epifany.com&type=default",
+              "ip": "66.102.8.4",
+              "recipient-domain": "epifany.com",
+              "id": "OQ9W5OphSMmk6WSomAUOdg",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579798749.003176,
+              "client-info": {
+                "client-type": "browser",
+                "device-type": "desktop",
+                "client-name": "Chrome",
+                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd049110_42b2a4e1f6bcc974fc@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=amanda.powell%40epifany.com&type=default",
+              "ip": "66.102.8.2",
+              "recipient-domain": "epifany.com",
+              "id": "vLbJl1idTWuUkavgTVAWbQ",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579798748.905914,
+              "client-info": {
+                "client-type": "browser",
+                "device-type": "desktop",
+                "client-name": "Chrome",
+                "user-agent": "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd049110_42b2a4e1f6bcc974fc@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=amanda.powell%40epifany.com&type=default",
+              "ip": "199.255.11.3",
+              "log-level": "info",
+              "id": "cD0y4L7ESU-GuQNpOfgdqw",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579798738.912346,
+              "client-info": {
+                "client-type": "browser",
+                "client-os": "Windows",
+                "device-type": "desktop",
+                "client-name": "Chrome",
+                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd049110_42b2a4e1f6bcc974fc@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798730.389662,
+              "log-level": "info",
+              "id": "-MOTOGnYQZSqdRHaJLvA4g",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "ip": "66.249.88.82",
+              "client-info": {
+                "client-os": "Windows",
+                "device-type": "desktop",
+                "client-name": "Firefox",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd049110_42b2a4e1f6bcc974fc@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=haley.rafols%40epifany.com&type=default",
+              "ip": "199.255.11.3",
+              "log-level": "info",
+              "id": "JZW2KU7eSJqysWv6hjfKNw",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579798728.269293,
+              "client-info": {
+                "client-type": "mobile browser",
+                "client-os": "iOS",
+                "device-type": "mobile",
+                "client-name": "Mobile Safari",
+                "user-agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.1 Mobile/15E148 Safari/604.1"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfcf52157_42b2a4e1f6bcc9733f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=haley.rafols%40epifany.com&type=default",
+              "timestamp": 1579798727.490603,
+              "log-level": "info",
+              "id": "m8qah3qjQE2t-x2LaV4tRw",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "ip": "66.102.8.4",
+              "client-info": {
+                "client-os": "Windows",
+                "device-type": "desktop",
+                "client-name": "Chrome",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 Edge/18.18362"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfcf52157_42b2a4e1f6bcc9733f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=haley.rafols%40epifany.com&type=default",
+              "ip": "66.102.8.30",
+              "recipient-domain": "epifany.com",
+              "id": "E4FWCbukS5CuKv7BZJQ-qg",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579798727.440789,
+              "client-info": {
+                "client-type": "browser",
+                "device-type": "desktop",
+                "client-name": "Chrome",
+                "user-agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfcf52157_42b2a4e1f6bcc9733f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=shawn.murphy%40epifany.com&type=default",
+              "ip": "66.102.8.2",
+              "recipient-domain": "epifany.com",
+              "id": "4p4HUudeTZ6tVIWcv1Pk6Q",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579798726.698092,
+              "client-info": {
+                "client-type": "browser",
+                "device-type": "desktop",
+                "client-name": "Chrome",
+                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfce55493_42b2a4e1f6bcc972f2@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=shawn.murphy%40epifany.com&type=default",
+              "ip": "66.102.8.3",
+              "log-level": "info",
+              "id": "nk_6GJfCSD-22-QlPftD0A",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579798726.679705,
+              "client-info": {
+                "client-type": "browser",
+                "client-os": "Windows",
+                "device-type": "desktop",
+                "client-name": "Chrome",
+                "user-agent": "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfce55493_42b2a4e1f6bcc972f2@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=shawn.murphy%40epifany.com&type=default",
+              "ip": "199.255.11.3",
+              "recipient-domain": "epifany.com",
+              "id": "JUEAkghmTiCRPFuh0tTFBQ",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579798723.19422,
+              "client-info": {
+                "client-name": "Chrome",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36",
+                "device-type": "desktop",
+                "client-os": "OS X"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfce55493_42b2a4e1f6bcc972f2@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "66.249.88.93",
+              "log-level": "info",
+              "id": "uWQpAmGQQU-blQwZvaRDyw",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579798721.536296,
+              "client-info": {
+                "client-type": "browser",
+                "client-os": "Windows",
+                "device-type": "desktop",
+                "client-name": "Firefox",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfce55493_42b2a4e1f6bcc972f2@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "66.249.88.66",
+              "log-level": "info",
+              "id": "b__nhLfUTNqddNBAmWeqOA",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579798712.120682,
+              "client-info": {
+                "client-type": "browser",
+                "client-os": "Windows",
+                "device-type": "desktop",
+                "client-name": "Firefox",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfcf52157_42b2a4e1f6bcc9733f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=stephen.morgan%40epifany.com&type=default",
+              "ip": "66.102.8.31",
+              "recipient-domain": "epifany.com",
+              "id": "8xnm94ZHRKekQTgQ1T6WtA",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579798700.321491,
+              "client-info": {
+                "client-name": "Chrome",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.1 (KHTML, like Gecko) Chrome/21.0.1180.83 Safari/537.1",
+                "device-type": "desktop",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd298eff_42b2a4e1f6bcc976c0@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=stephen.morgan%40epifany.com&type=default",
+              "ip": "66.102.8.3",
+              "recipient-domain": "epifany.com",
+              "id": "jUn3N2eNT66tRU7Gc1f6pQ",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579798700.202002,
+              "client-info": {
+                "client-name": "Chrome",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36",
+                "device-type": "desktop",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd298eff_42b2a4e1f6bcc976c0@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=stephen.morgan%40epifany.com&type=default",
+              "ip": "199.255.11.3",
+              "log-level": "info",
+              "id": "M0DlRSNyTbGkafpsX-mO9Q",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579798692.041743,
+              "client-info": {
+                "client-type": "browser",
+                "client-os": "Windows",
+                "device-type": "desktop",
+                "client-name": "Chrome",
+                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd298eff_42b2a4e1f6bcc976c0@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "66.249.88.93",
+              "recipient-domain": "epifany.com",
+              "id": "kaS_Rh86T1OCyK7yKck3Mg",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579798687.406244,
+              "client-info": {
+                "client-name": "Firefox",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)",
+                "device-type": "desktop",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd298eff_42b2a4e1f6bcc976c0@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798651.722366,
+              "log-level": "info",
+              "id": "XJTBPgCMQ3ylED0-hVANnA",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "ip": "66.249.88.83",
+              "client-info": {
+                "client-os": "Windows",
+                "device-type": "desktop",
+                "client-name": "Firefox",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd298eff_42b2a4e1f6bcc976c0@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798644.151274,
+              "log-level": "info",
+              "id": "iUtkXQdgR3WtdhcDWylUcQ",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "ip": "66.249.88.83",
+              "client-info": {
+                "client-os": "Windows",
+                "device-type": "desktop",
+                "client-name": "Firefox",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfcf52157_42b2a4e1f6bcc9733f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798631.242406,
+              "log-level": "info",
+              "id": "ZUxBe_wjQtazcNZu3bM4sQ",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "ip": "66.249.88.81",
+              "client-info": {
+                "client-os": "Windows",
+                "device-type": "desktop",
+                "client-name": "Firefox",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd19a012_42b2a4e1f6bcc9752f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "66.249.88.93",
+              "recipient-domain": "epifany.com",
+              "id": "S2oeD_cIRny30cFCOMHKZQ",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579798624.626998,
+              "client-info": {
+                "client-name": "Firefox",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)",
+                "device-type": "desktop",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfce55493_42b2a4e1f6bcc972f2@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "66.249.88.79",
+              "recipient-domain": "epifany.com",
+              "id": "CbFj7ycHSaaLSLw1sHl-wA",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579798604.08809,
+              "client-info": {
+                "client-type": "browser",
+                "device-type": "desktop",
+                "client-name": "Firefox",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e29cfd049110_42b2a4e1f6bcc974fc@58999e8c-a86f-45e4-ad9a-416d097d08de.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFHLOKXR8ICru1O0ZPw6XwCP8PtJpJZA==",
+                "key": "AgEFHLOKXR8ICru1O0ZPw6XwCP8PtJpJZA=="
+              },
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 3.499413013458252,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "log-level": "info",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579798492.886562,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e29cfd298eff_42b2a4e1f6bcc976c0@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Stephen Morgan, NC Opera Wants to Hear From You! [stephen.morgan@epifany.com]"
+                },
+                "attachments": [],
+                "size": 40636
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "id": "KvXnFo0HQhSn9zXRJSu3KQ"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFHLOKXR8ICru1O0ZPw6XwCP8PtJpJZA==",
+                "key": "AgEFHLOKXR8ICru1O0ZPw6XwCP8PtJpJZA=="
+              },
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 3.241486072540283,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "log-level": "info",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579798491.899583,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "leonel.galan+sandbox@epifany.com",
+                  "message-id": "5e29cfd298eff_42b2a4e1f6bcc976c0@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Stephen Morgan, NC Opera Wants to Hear From You! [stephen.morgan@epifany.com]"
+                },
+                "attachments": [],
+                "size": 40646
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "mJrhK45dSd64ZGwC8vOxXw"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFAVoXPwn-F0BekGFH9ooddMGK7_nRZA==",
+                "key": "AgEFAVoXPwn-F0BekGFH9ooddMGK7_nRZA=="
+              },
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 3.001133918762207,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "log-level": "info",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579798488.22732,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e29cfd19a012_42b2a4e1f6bcc9752f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Julie Barberio, NC Opera Wants to Hear From You! [julie.barberio@epifany.com]"
+                },
+                "attachments": [],
+                "size": 40641
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "id": "ZGb_ZHmpRrOM8uU8jxF6Kg"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798488.074987,
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEF6gagxfjI9QDYGRRH6LinFRTTh_hpZA==",
+                "key": "AgEF6gagxfjI9QDYGRRH6LinFRTTh_hpZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "id": "zRxmYI7XSYaI4dwetMeVog",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "leonel.galan+sandbox@epifany.com",
+                  "message-id": "5e29cfcf52157_42b2a4e1f6bcc9733f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Haley Rafols, NC Opera Wants to Hear From You! [haley.rafols@epifany.com]"
+                },
+                "attachments": [],
+                "size": 40634
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "delivered",
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "code": 250,
+                "description": "",
+                "session-seconds": 2.7583799362182617,
+                "utf8": true,
+                "attempt-no": 1,
+                "message": "OK",
+                "certificate-verified": true
+              }
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798487.735178,
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEF6gagxfjI9QDYGRRH6LinFRTTh_hpZA==",
+                "key": "AgEF6gagxfjI9QDYGRRH6LinFRTTh_hpZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "id": "0O8cJVw6RkWbeFfprjCZSA",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e29cfcf52157_42b2a4e1f6bcc9733f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Haley Rafols, NC Opera Wants to Hear From You! [haley.rafols@epifany.com]"
+                },
+                "attachments": [],
+                "size": 40623
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "delivered",
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "code": 250,
+                "description": "",
+                "session-seconds": 2.907418966293335,
+                "utf8": true,
+                "attempt-no": 1,
+                "message": "OK",
+                "certificate-verified": true
+              }
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798486.069942,
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFSxR8AYnz1MyIEPRN6pswTRzd_p_pZA==",
+                "key": "AgEFSxR8AYnz1MyIEPRN6pswTRzd_p_pZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "id": "DSER6IgvRQiwZU2Mdl5KGA",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "leonel.galan+sandbox@epifany.com",
+                  "message-id": "5e29cfce55493_42b2a4e1f6bcc972f2@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Shawn Murphy, NC Opera Wants to Hear From You! [shawn.murphy@epifany.com]"
+                },
+                "attachments": [],
+                "size": 40639
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "delivered",
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "code": 250,
+                "description": "",
+                "session-seconds": 3.153596878051758,
+                "utf8": true,
+                "attempt-no": 1,
+                "message": "OK",
+                "certificate-verified": true
+              }
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFAVoXPwn-F0BekGFH9ooddMGK7_nRZA==",
+                "key": "AgEFAVoXPwn-F0BekGFH9ooddMGK7_nRZA=="
+              },
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 2.1263840198516846,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "log-level": "info",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579798485.837238,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "leonel.galan+sandbox@epifany.com",
+                  "message-id": "5e29cfd19a012_42b2a4e1f6bcc9752f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Julie Barberio, NC Opera Wants to Hear From You! [julie.barberio@epifany.com]"
+                },
+                "attachments": [],
+                "size": 40635
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "2_QCQZKNRIGgtg-1naeNvg"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798484.995067,
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFSxR8AYnz1MyIEPRN6pswTRzd_p_pZA==",
+                "key": "AgEFSxR8AYnz1MyIEPRN6pswTRzd_p_pZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "id": "GVdsNYppS5eVbjXDC4fYZg",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e29cfce55493_42b2a4e1f6bcc972f2@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Shawn Murphy, NC Opera Wants to Hear From You! [shawn.murphy@epifany.com]"
+                },
+                "attachments": [],
+                "size": 40636
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "delivered",
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "code": 250,
+                "description": "",
+                "session-seconds": 2.280358076095581,
+                "utf8": true,
+                "attempt-no": 1,
+                "message": "OK",
+                "certificate-verified": true
+              }
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798483.1945043,
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFHLOKXR8ICru1O0ZPw6XwCP8PtJpJZA==",
+                "key": "AgEFHLOKXR8ICru1O0ZPw6XwCP8PtJpJZA=="
+              },
+              "log-level": "info",
+              "event": "accepted",
+              "method": "http",
+              "user-variables": {},
+              "flags": {
+                "is-authenticated": true,
+                "is-test-mode": false
+              },
+              "recipient-domain": "epifany.com",
+              "envelope": {
+                "sender": "postmaster@DOMAIN.TEST",
+                "transport": "smtp",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "%recipient%",
+                  "message-id": "5e29cfd298eff_42b2a4e1f6bcc976c0@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Stephen Morgan, NC Opera Wants to Hear From You! [stephen.morgan@epifany.com]"
+                },
+                "size": 37789
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "id": "WCB2ESIRRe-EB-HfE-5FyA"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798483.1220677,
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFHLOKXR8ICru1O0ZPw6XwCP8PtJpJZA==",
+                "key": "AgEFHLOKXR8ICru1O0ZPw6XwCP8PtJpJZA=="
+              },
+              "log-level": "info",
+              "event": "accepted",
+              "method": "http",
+              "user-variables": {},
+              "flags": {
+                "is-authenticated": true,
+                "is-test-mode": false
+              },
+              "recipient-domain": "epifany.com",
+              "envelope": {
+                "sender": "postmaster@DOMAIN.TEST",
+                "transport": "smtp",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "%recipient%",
+                  "message-id": "5e29cfd298eff_42b2a4e1f6bcc976c0@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Stephen Morgan, NC Opera Wants to Hear From You! [stephen.morgan@epifany.com]"
+                },
+                "size": 37789
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "aGrvaVVfSSGvki8-HBjh-w"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798483.017343,
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEF-u7c5B13GIBY0hhDqI4X1vi66zcwZA==",
+                "key": "AgEF-u7c5B13GIBY0hhDqI4X1vi66zcwZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "id": "6joY9M35RA-EWZLnnpc0dA",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "leonel.galan+sandbox@epifany.com",
+                  "message-id": "5e29cfd049110_42b2a4e1f6bcc974fc@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Amanda Powell, NC Opera Wants to Hear From You! [amanda.powell@epifany.com]"
+                },
+                "attachments": [],
+                "size": 40641
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "delivered",
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "code": 250,
+                "description": "",
+                "session-seconds": 1.4664008617401123,
+                "utf8": true,
+                "attempt-no": 1,
+                "message": "OK",
+                "certificate-verified": true
+              }
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEF-u7c5B13GIBY0hhDqI4X1vi66zcwZA==",
+                "key": "AgEF-u7c5B13GIBY0hhDqI4X1vi66zcwZA=="
+              },
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 0.6860668659210205,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "log-level": "info",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579798482.199233,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e29cfd049110_42b2a4e1f6bcc974fc@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Amanda Powell, NC Opera Wants to Hear From You! [amanda.powell@epifany.com]"
+                },
+                "attachments": [],
+                "size": 40637
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "id": "T_9pYpqjRLK3u_l0TbQw3A"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798482.178251,
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFAVoXPwn-F0BekGFH9ooddMGK7_nRZA==",
+                "key": "AgEFAVoXPwn-F0BekGFH9ooddMGK7_nRZA=="
+              },
+              "envelope": {
+                "sender": "postmaster@DOMAIN.TEST",
+                "transport": "smtp",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "log-level": "info",
+              "id": "8mokKeB1QrGcgneKTXm9bw",
+              "method": "http",
+              "user-variables": {},
+              "flags": {
+                "is-authenticated": true,
+                "is-test-mode": false
+              },
+              "recipient-domain": "epifany.com",
+              "message": {
+                "headers": {
+                  "to": "%recipient%",
+                  "message-id": "5e29cfd19a012_42b2a4e1f6bcc9752f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Julie Barberio, NC Opera Wants to Hear From You! [julie.barberio@epifany.com]"
+                },
+                "size": 37789
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "accepted"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798482.1335177,
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFAVoXPwn-F0BekGFH9ooddMGK7_nRZA==",
+                "key": "AgEFAVoXPwn-F0BekGFH9ooddMGK7_nRZA=="
+              },
+              "log-level": "info",
+              "event": "accepted",
+              "method": "http",
+              "user-variables": {},
+              "flags": {
+                "is-authenticated": true,
+                "is-test-mode": false
+              },
+              "recipient-domain": "epifany.com",
+              "envelope": {
+                "sender": "postmaster@DOMAIN.TEST",
+                "transport": "smtp",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "%recipient%",
+                  "message-id": "5e29cfd19a012_42b2a4e1f6bcc9752f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Julie Barberio, NC Opera Wants to Hear From You! [julie.barberio@epifany.com]"
+                },
+                "size": 37789
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "vSMmMWJqSpmTAcLLLvOh-w"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798481.0728397,
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEF-u7c5B13GIBY0hhDqI4X1vi66zcwZA==",
+                "key": "AgEF-u7c5B13GIBY0hhDqI4X1vi66zcwZA=="
+              },
+              "envelope": {
+                "sender": "postmaster@DOMAIN.TEST",
+                "transport": "smtp",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "log-level": "info",
+              "id": "IMKjoFBYTEyNm7Ok6_addg",
+              "method": "http",
+              "user-variables": {},
+              "flags": {
+                "is-authenticated": true,
+                "is-test-mode": false
+              },
+              "recipient-domain": "epifany.com",
+              "message": {
+                "headers": {
+                  "to": "%recipient%",
+                  "message-id": "5e29cfd049110_42b2a4e1f6bcc974fc@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Amanda Powell, NC Opera Wants to Hear From You! [amanda.powell@epifany.com]"
+                },
+                "size": 37785
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "accepted"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798481.017749,
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEF-u7c5B13GIBY0hhDqI4X1vi66zcwZA==",
+                "key": "AgEF-u7c5B13GIBY0hhDqI4X1vi66zcwZA=="
+              },
+              "log-level": "info",
+              "event": "accepted",
+              "method": "http",
+              "user-variables": {},
+              "flags": {
+                "is-authenticated": true,
+                "is-test-mode": false
+              },
+              "recipient-domain": "epifany.com",
+              "envelope": {
+                "sender": "postmaster@DOMAIN.TEST",
+                "transport": "smtp",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "%recipient%",
+                  "message-id": "5e29cfd049110_42b2a4e1f6bcc974fc@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Amanda Powell, NC Opera Wants to Hear From You! [amanda.powell@epifany.com]"
+                },
+                "size": 37785
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "f8etV7jCTAuJJA4uXqr9vw"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798479.9070146,
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEF6gagxfjI9QDYGRRH6LinFRTTh_hpZA==",
+                "key": "AgEF6gagxfjI9QDYGRRH6LinFRTTh_hpZA=="
+              },
+              "log-level": "info",
+              "event": "accepted",
+              "method": "http",
+              "user-variables": {},
+              "flags": {
+                "is-authenticated": true,
+                "is-test-mode": false
+              },
+              "recipient-domain": "epifany.com",
+              "envelope": {
+                "sender": "postmaster@DOMAIN.TEST",
+                "transport": "smtp",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "%recipient%",
+                  "message-id": "5e29cfcf52157_42b2a4e1f6bcc9733f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Haley Rafols, NC Opera Wants to Hear From You! [haley.rafols@epifany.com]"
+                },
+                "size": 37781
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "id": "zQKCMzzSTFmzsJ6o0b6JGw"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798479.8918307,
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEF6gagxfjI9QDYGRRH6LinFRTTh_hpZA==",
+                "key": "AgEF6gagxfjI9QDYGRRH6LinFRTTh_hpZA=="
+              },
+              "log-level": "info",
+              "event": "accepted",
+              "method": "http",
+              "user-variables": {},
+              "flags": {
+                "is-authenticated": true,
+                "is-test-mode": false
+              },
+              "recipient-domain": "epifany.com",
+              "envelope": {
+                "sender": "postmaster@DOMAIN.TEST",
+                "transport": "smtp",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "%recipient%",
+                  "message-id": "5e29cfcf52157_42b2a4e1f6bcc9733f@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Haley Rafols, NC Opera Wants to Hear From You! [haley.rafols@epifany.com]"
+                },
+                "size": 37781
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "eYGZ14l_TGeinDAVeBKZbA"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798478.9227521,
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFSxR8AYnz1MyIEPRN6pswTRzd_p_pZA==",
+                "key": "AgEFSxR8AYnz1MyIEPRN6pswTRzd_p_pZA=="
+              },
+              "log-level": "info",
+              "event": "accepted",
+              "method": "http",
+              "user-variables": {},
+              "flags": {
+                "is-authenticated": true,
+                "is-test-mode": false
+              },
+              "recipient-domain": "epifany.com",
+              "envelope": {
+                "sender": "postmaster@DOMAIN.TEST",
+                "transport": "smtp",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "%recipient%",
+                  "message-id": "5e29cfce55493_42b2a4e1f6bcc972f2@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Shawn Murphy, NC Opera Wants to Hear From You! [shawn.murphy@epifany.com]"
+                },
+                "size": 37781
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "id": "TyT3A3bvTHqt49vA3OhN4Q"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579798478.9100864,
+              "storage": {
+                "url": "https://sw.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFSxR8AYnz1MyIEPRN6pswTRzd_p_pZA==",
+                "key": "AgEFSxR8AYnz1MyIEPRN6pswTRzd_p_pZA=="
+              },
+              "envelope": {
+                "sender": "postmaster@DOMAIN.TEST",
+                "transport": "smtp",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "log-level": "info",
+              "id": "y8h1BeVKQPG89mrSoCHugw",
+              "method": "http",
+              "user-variables": {},
+              "flags": {
+                "is-authenticated": true,
+                "is-test-mode": false
+              },
+              "recipient-domain": "epifany.com",
+              "message": {
+                "headers": {
+                  "to": "%recipient%",
+                  "message-id": "5e29cfce55493_42b2a4e1f6bcc972f2@58999e8c-a86f-45e4-ad9a-416d097d08de.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Shawn Murphy, NC Opera Wants to Hear From You! [shawn.murphy@epifany.com]"
+                },
+                "size": 37781
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "accepted"
+            },
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-unsubscribe.epifany.com/opera?address=lukasbbarry%40gmail.com&id=200787&tag=OPERA+Fill+Survey",
+              "timestamp": 1579796212.01093,
+              "log-level": "info",
+              "id": "uWAKSMAnSJuWlSiQfOhp0g",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "ip": "199.255.11.3",
+              "client-info": {
+                "client-os": "OS X",
+                "device-type": "desktop",
+                "client-name": "Chrome",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e280f144ce3a_42ab8d92ffd481183e@9ba4b181-8ea5-4dfe-81eb-2c3c8803d88b.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-unsubscribe.epifany.com/opera?address=lukasbbarry%40gmail.com&id=200787&tag=OPERA+Fill+Survey",
+              "ip": "199.255.11.3",
+              "recipient-domain": "epifany.com",
+              "id": "xbl1B2G3QRiXLXLLSwdo6Q",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579795853.484523,
+              "client-info": {
+                "client-name": "Chrome",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
+                "device-type": "desktop",
+                "client-os": "OS X"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e280f144ce3a_42ab8d92ffd481183e@9ba4b181-8ea5-4dfe-81eb-2c3c8803d88b.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "66.249.88.93",
+              "recipient-domain": "epifany.com",
+              "id": "aXjCvQzkT7qTFj8Ok9EiNg",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579795850.854494,
+              "client-info": {
+                "client-name": "Firefox",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)",
+                "device-type": "desktop",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e280f144ce3a_42ab8d92ffd481183e@9ba4b181-8ea5-4dfe-81eb-2c3c8803d88b.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "66.249.88.78",
+              "recipient-domain": "epifany.com",
+              "id": "ASyMeGojQTewFH2pBW-6kQ",
+              "campaigns": [],
+              "user-variables": {},
+              "log-level": "info",
+              "timestamp": 1579726141.706892,
+              "client-info": {
+                "client-name": "Firefox",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)",
+                "device-type": "desktop",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e289108a02e9_42ab9a0a077f41058e8@9a8aefa4-d584-42c5-8d52-1adac175810d.mail"
+                }
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "66.249.88.78",
+              "log-level": "info",
+              "id": "lepBvEw8Qy-0KTzZn22Fdw",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579723612.309751,
+              "client-info": {
+                "client-type": "browser",
+                "client-os": "Windows",
+                "device-type": "desktop",
+                "client-name": "Firefox",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e2890e23279f_42ab9a0a077f4999d9@9a8aefa4-d584-42c5-8d52-1adac175810d.mail"
+                }
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "66.249.88.87",
+              "log-level": "info",
+              "id": "OaGyqem8QJmLWZFcFMzi3g",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579723601.28057,
+              "client-info": {
+                "client-name": "Firefox",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)",
+                "device-type": "desktop",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e28906993d01_42ab9a0a077f4880c1@9a8aefa4-d584-42c5-8d52-1adac175810d.mail"
+                }
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "country": "US",
+                "region": "Unknown",
+                "city": "Unknown"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "66.249.88.83",
+              "log-level": "info",
+              "event": "opened",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579723601.258764,
+              "client-info": {
+                "client-name": "Firefox",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)",
+                "device-type": "desktop",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e28907bde058_42ab9a0a077f4903bb@9a8aefa4-d584-42c5-8d52-1adac175810d.mail"
+                }
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "dvZMSBHfQj6d3p9yz9EYUg"
+            },
+            {
+              "geolocation": {
+                "country": "US",
+                "region": "NC",
+                "city": "Raleigh"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=clairethompson615%40yahoo.com&type=default",
+              "ip": "199.255.11.3",
+              "log-level": "info",
+              "event": "clicked",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579717774.989463,
+              "client-info": {
+                "client-name": "Chrome",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36",
+                "device-type": "desktop",
+                "client-os": "OS X"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e2890c73beb7_42ab9a0a077f49705d@9a8aefa4-d584-42c5-8d52-1adac175810d.mail"
+                }
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "8hyMxlDkS2q3uMd9XudkIA"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "66.249.88.176",
+              "log-level": "info",
+              "id": "Z5n6TmaiTRur9SAwbAT5SA",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579717773.342642,
+              "client-info": {
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)",
+                "client-name": "Firefox",
+                "device-type": "desktop",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e2890c73beb7_42ab9a0a077f49705d@9a8aefa4-d584-42c5-8d52-1adac175810d.mail"
+                }
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "geolocation": {
+                "country": "US",
+                "region": "Unknown",
+                "city": "Unknown"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "66.249.88.184",
+              "log-level": "info",
+              "event": "opened",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579717773.112847,
+              "client-info": {
+                "client-name": "Firefox",
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)",
+                "device-type": "desktop",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e2890e8ac63c_42ab9a0a077f4100799@9a8aefa4-d584-42c5-8d52-1adac175810d.mail"
+                }
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "Not720HZSQux4KRLUw-mtQ"
+            },
+            {
+              "geolocation": {
+                "city": "Raleigh",
+                "region": "NC",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "url": "https://test-web.epifany.com/opera?major=2444&email=cczentorychy%40yahoo.com&type=default",
+              "ip": "199.255.11.3",
+              "log-level": "info",
+              "id": "eD7eN018QuuLRnUUTn6qKA",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579717564.400899,
+              "client-info": {
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36",
+                "client-name": "Chrome",
+                "device-type": "desktop",
+                "client-os": "OS X"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e2890261f771_42ab9a0a077f481968@9a8aefa4-d584-42c5-8d52-1adac175810d.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "clicked"
+            },
+            {
+              "geolocation": {
+                "city": "Unknown",
+                "region": "Unknown",
+                "country": "US"
+              },
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "ip": "66.249.88.174",
+              "log-level": "info",
+              "id": "69rhuiRORyuX_smd8QbsMw",
+              "campaigns": [],
+              "user-variables": {},
+              "recipient-domain": "epifany.com",
+              "timestamp": 1579717475.72526,
+              "client-info": {
+                "client-type": "browser",
+                "user-agent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)",
+                "client-name": "Firefox",
+                "device-type": "desktop",
+                "client-os": "Windows"
+              },
+              "message": {
+                "headers": {
+                  "message-id": "5e2890261f771_42ab9a0a077f481968@9a8aefa4-d584-42c5-8d52-1adac175810d.mail"
+                }
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "opened"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 5.27187705039978,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFheJPHaQMJsBZzTZJho9jWthE8XFzZA==",
+                "key": "AgEFheJPHaQMJsBZzTZJho9jWthE8XFzZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "timestamp": 1579716882.817898,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e289108a02e9_42ab9a0a077f41058e8@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Charles Lankford, NC Opera Wants to Hear From You! [tracy.kahn@pharma-sys.com]"
+                },
+                "attachments": [],
+                "size": 40656
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "id": "9JsqmEr3SiyQB4hhyZ-Caw"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 3.914803981781006,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFheJPHaQMJsBZzTZJho9jWthE8XFzZA==",
+                "key": "AgEFheJPHaQMJsBZzTZJho9jWthE8XFzZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "timestamp": 1579716881.103367,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "leonel.galan+sandbox@epifany.com",
+                  "message-id": "5e289108a02e9_42ab9a0a077f41058e8@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Charles Lankford, NC Opera Wants to Hear From You! [tracy.kahn@pharma-sys.com]"
+                },
+                "attachments": [],
+                "size": 40667
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "5Rz-LM0MRKqX0jXvVmCA1w"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579716879.085171,
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFO1ZctGNyuTHrKnVPVpcn1nWr4wyNZA==",
+                "key": "AgEFO1ZctGNyuTHrKnVPVpcn1nWr4wyNZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "id": "APiRVAa9RR6kXNMPbN2Rvg",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "leonel.galan+sandbox@epifany.com",
+                  "message-id": "5e289106b664e_42ab9a0a077f410553@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Tom Wentley, NC Opera Wants to Hear From You! [tbwentley@yahoo.com]"
+                },
+                "attachments": [],
+                "size": 40630
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "delivered",
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "code": 250,
+                "description": "",
+                "session-seconds": 4.43303108215332,
+                "utf8": true,
+                "attempt-no": 1,
+                "message": "OK",
+                "certificate-verified": true
+              }
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 4.344880819320679,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFO1ZctGNyuTHrKnVPVpcn1nWr4wyNZA==",
+                "key": "AgEFO1ZctGNyuTHrKnVPVpcn1nWr4wyNZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "timestamp": 1579716879.075831,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e289106b664e_42ab9a0a077f410553@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Tom Wentley, NC Opera Wants to Hear From You! [tbwentley@yahoo.com]"
+                },
+                "attachments": [],
+                "size": 40632
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "id": "5XqO0xDdS8uXKKIaSR_uYg"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 3.748795986175537,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEF4bvG5uKPhtejqtNCcYCdlzhIWHjHZA==",
+                "key": "AgEF4bvG5uKPhtejqtNCcYCdlzhIWHjHZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "timestamp": 1579716878.809767,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "leonel.galan+sandbox@epifany.com",
+                  "message-id": "5e289106ba9b_42ab9a0a077f4105435@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Katy Sherman, NC Opera Wants to Hear From You! [katysherm@gmail.com]"
+                },
+                "attachments": [],
+                "size": 40631
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "SzaNyzHVRw6soqBVMgn2Pg"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 3.877161979675293,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEF4bvG5uKPhtejqtNCcYCdlzhIWHjHZA==",
+                "key": "AgEF4bvG5uKPhtejqtNCcYCdlzhIWHjHZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "timestamp": 1579716878.608885,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e289106ba9b_42ab9a0a077f4105435@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Katy Sherman, NC Opera Wants to Hear From You! [katysherm@gmail.com]"
+                },
+                "attachments": [],
+                "size": 40620
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "id": "Fp4_qMuiRLmS6sMRd0dAIQ"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 4.061612844467163,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFhmTjxtMpfbInpw5Ck6I-D3IJ6XgSZA==",
+                "key": "AgEFhmTjxtMpfbInpw5Ck6I-D3IJ6XgSZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "timestamp": 1579716878.595035,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e2891037f59c_42ab9a0a077f4105027@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Steve Kutay, NC Opera Wants to Hear From You! [skutay1@gmail.com]"
+                },
+                "attachments": [],
+                "size": 40626
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "id": "rf_e_CikSSybE0RNxpmc_w"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 4.399448871612549,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFhmTjxtMpfbInpw5Ck6I-D3IJ6XgSZA==",
+                "key": "AgEFhmTjxtMpfbInpw5Ck6I-D3IJ6XgSZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "timestamp": 1579716876.959879,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "leonel.galan+sandbox@epifany.com",
+                  "message-id": "5e2891037f59c_42ab9a0a077f4105027@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Steve Kutay, NC Opera Wants to Hear From You! [skutay1@gmail.com]"
+                },
+                "attachments": [],
+                "size": 40634
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "HG387-1fS8aMo-V3XwxnMg"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579716876.735753,
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFpXX4do-MQ8BB3EFHN5YIies4LYObZA==",
+                "key": "AgEFpXX4do-MQ8BB3EFHN5YIies4LYObZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "id": "jFRs2UxlQHKsXRrFI_SUUQ",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e289102d311f_42ab9a0a077f4104993@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Ralph & Francine Roberson, NC Opera Wants to Hear From You! [roberson@rmb-consulting.com]"
+                },
+                "attachments": [],
+                "size": 40674
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "delivered",
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "code": 250,
+                "description": "",
+                "session-seconds": 5.329949855804443,
+                "utf8": true,
+                "attempt-no": 1,
+                "message": "OK",
+                "certificate-verified": true
+              }
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579716876.078911,
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFiFs3FuePE56WmQRG0pQ2aXy9CH8EZA==",
+                "key": "AgEFiFs3FuePE56WmQRG0pQ2aXy9CH8EZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "id": "T59bkJ9aSRKtE7yiuIecSQ",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "leonel.galan+sandbox@epifany.com",
+                  "message-id": "5e2891075ec8e_42ab9a0a077f41056cf@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Marko Zivkovic, NC Opera Wants to Hear From You! [marko.zivkovicsrb@gmail.com]"
+                },
+                "attachments": [],
+                "size": 40678
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "delivered",
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "code": 250,
+                "description": "",
+                "session-seconds": 1.0185539722442627,
+                "utf8": true,
+                "attempt-no": 1,
+                "message": "OK",
+                "certificate-verified": true
+              }
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 3.914436101913452,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFovcL34n3Ma1tRL1H94ugvAMYBe-DZA==",
+                "key": "AgEFovcL34n3Ma1tRL1H94ugvAMYBe-DZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "timestamp": 1579716875.663838,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e28910428370_42ab9a0a077f4105126@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Michelle Thompson, NC Opera Wants to Hear From You! [mhholbrook@gmail.com]"
+                },
+                "attachments": [],
+                "size": 40645
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "id": "Ctd3KxHbTmy9MJVWngs7SQ"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579716875.440851,
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFxuXgXe7o3P2oxx5BQoSt0wevOUAcZA==",
+                "key": "AgEFxuXgXe7o3P2oxx5BQoSt0wevOUAcZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "id": "DHKaSON7TIKUz3WamceERw",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e28910228818_42ab9a0a077f410487d@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Douglas Poole, NC Opera Wants to Hear From You! [douglasepoole21@yahoo.com]"
+                },
+                "attachments": [],
+                "size": 40653
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "delivered",
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "code": 250,
+                "description": "",
+                "session-seconds": 5.201658010482788,
+                "utf8": true,
+                "attempt-no": 1,
+                "message": "OK",
+                "certificate-verified": true
+              }
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 4.868946075439453,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFxuXgXe7o3P2oxx5BQoSt0wevOUAcZA==",
+                "key": "AgEFxuXgXe7o3P2oxx5BQoSt0wevOUAcZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "timestamp": 1579716875.131806,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "leonel.galan+sandbox@epifany.com",
+                  "message-id": "5e28910228818_42ab9a0a077f410487d@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Douglas Poole, NC Opera Wants to Hear From You! [douglasepoole21@yahoo.com]"
+                },
+                "attachments": [],
+                "size": 40656
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "DgZKhux9RnKxcOMIfxFhWA"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 4.361043930053711,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFpXX4do-MQ8BB3EFHN5YIies4LYObZA==",
+                "key": "AgEFpXX4do-MQ8BB3EFHN5YIies4LYObZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "timestamp": 1579716875.092451,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "leonel.galan+sandbox@epifany.com",
+                  "message-id": "5e289102d311f_42ab9a0a077f4104993@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Ralph & Francine Roberson, NC Opera Wants to Hear From You! [roberson@rmb-consulting.com]"
+                },
+                "attachments": [],
+                "size": 40683
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "wz6sux2-TE-BA4WZy07dBw"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579716873.950286,
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFrXM72YSL_wMOmi5AyrCAEb6UZjFkZA==",
+                "key": "AgEFrXM72YSL_wMOmi5AyrCAEb6UZjFkZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "id": "cJ-HB84PSKaJahtRlmG7lg",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e289104cfccb_42ab9a0a077f4105290@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Jane Lynch, NC Opera Wants to Hear From You! [janilu@mindspring.com]"
+                },
+                "attachments": [],
+                "size": 40645
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "delivered",
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "code": 250,
+                "description": "",
+                "session-seconds": 1.9385089874267578,
+                "utf8": true,
+                "attempt-no": 1,
+                "message": "OK",
+                "certificate-verified": true
+              }
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579716873.876334,
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFNUNZMGftxlXIQDJEN4LqKFWRI-_kZA==",
+                "key": "AgEFNUNZMGftxlXIQDJEN4LqKFWRI-_kZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "id": "0DhjJ-QZShe_Y1bT1gDKLw",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e2891081eb66_42ab9a0a077f41057f0@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Timothy Stammers, NC Opera Wants to Hear From You! [tomit613@gmail.com]"
+                },
+                "attachments": [],
+                "size": 40640
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "delivered",
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "code": 250,
+                "description": "",
+                "session-seconds": 0.528048038482666,
+                "utf8": true,
+                "attempt-no": 1,
+                "message": "OK",
+                "certificate-verified": true
+              }
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579716873.789008,
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFNUNZMGftxlXIQDJEN4LqKFWRI-_kZA==",
+                "key": "AgEFNUNZMGftxlXIQDJEN4LqKFWRI-_kZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "id": "sMm-gRhgTp2EDTw08Laezw",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "leonel.galan+sandbox@epifany.com",
+                  "message-id": "5e2891081eb66_42ab9a0a077f41057f0@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Timothy Stammers, NC Opera Wants to Hear From You! [tomit613@gmail.com]"
+                },
+                "attachments": [],
+                "size": 40640
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "delivered",
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "code": 250,
+                "description": "",
+                "session-seconds": 0.40761780738830566,
+                "utf8": true,
+                "attempt-no": 1,
+                "message": "OK",
+                "certificate-verified": true
+              }
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 2.5005218982696533,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFovcL34n3Ma1tRL1H94ugvAMYBe-DZA==",
+                "key": "AgEFovcL34n3Ma1tRL1H94ugvAMYBe-DZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "timestamp": 1579716873.474099,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "leonel.galan+sandbox@epifany.com",
+                  "message-id": "5e28910428370_42ab9a0a077f4105126@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Michelle Thompson, NC Opera Wants to Hear From You! [mhholbrook@gmail.com]"
+                },
+                "attachments": [],
+                "size": 40653
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "NjGzJi-NRqWYsnqbPH_u5w"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579716873.343551,
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFrXM72YSL_wMOmi5AyrCAEb6UZjFkZA==",
+                "key": "AgEFrXM72YSL_wMOmi5AyrCAEb6UZjFkZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "id": "rb5MUnwhSQCOZc_YFj40VA",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "leonel.galan+sandbox@epifany.com",
+                  "message-id": "5e289104cfccb_42ab9a0a077f4105290@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Jane Lynch, NC Opera Wants to Hear From You! [janilu@mindspring.com]"
+                },
+                "attachments": [],
+                "size": 40658
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "delivered",
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "code": 250,
+                "description": "",
+                "session-seconds": 0.7119250297546387,
+                "utf8": true,
+                "attempt-no": 1,
+                "message": "OK",
+                "certificate-verified": true
+              }
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 2.9347450733184814,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFcDrHSKuuR5zZjxVCe6vUGqbzm1FTZA==",
+                "key": "AgEFcDrHSKuuR5zZjxVCe6vUGqbzm1FTZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "timestamp": 1579716873.151834,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e28910578de1_42ab9a0a077f41053b2@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Jo Murray, NC Opera Wants to Hear From You! [jocarolmurray@gmail.com]"
+                },
+                "attachments": [],
+                "size": 40651
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "id": "ER8Y15ibRCqmbpd9FhdsTg"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFheJPHaQMJsBZzTZJho9jWthE8XFzZA==",
+                "key": "AgEFheJPHaQMJsBZzTZJho9jWthE8XFzZA=="
+              },
+              "envelope": {
+                "targets": "lukas.barry+sandbox@epifany.com",
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST"
+              },
+              "recipient-domain": "epifany.com",
+              "method": "http",
+              "user-variables": {},
+              "flags": {
+                "is-authenticated": true,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "timestamp": 1579716872.8307364,
+              "id": "DOCmCnoSQuSPEraRiN_b2w",
+              "message": {
+                "headers": {
+                  "to": "%recipient%",
+                  "message-id": "5e289108a02e9_42ab9a0a077f41058e8@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Charles Lankford, NC Opera Wants to Hear From You! [tracy.kahn@pharma-sys.com]"
+                },
+                "size": 37789
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "event": "accepted"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579716872.7787228,
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFheJPHaQMJsBZzTZJho9jWthE8XFzZA==",
+                "key": "AgEFheJPHaQMJsBZzTZJho9jWthE8XFzZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "accepted",
+              "method": "http",
+              "user-variables": {},
+              "flags": {
+                "is-authenticated": true,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "envelope": {
+                "targets": "leonel.galan+sandbox@epifany.com",
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST"
+              },
+              "message": {
+                "headers": {
+                  "to": "%recipient%",
+                  "message-id": "5e289108a02e9_42ab9a0a077f41058e8@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Charles Lankford, NC Opera Wants to Hear From You! [tracy.kahn@pharma-sys.com]"
+                },
+                "size": 37789
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "dKh2e6bqQyKUs4ENAlIk1Q"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 0.4027690887451172,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFiFs3FuePE56WmQRG0pQ2aXy9CH8EZA==",
+                "key": "AgEFiFs3FuePE56WmQRG0pQ2aXy9CH8EZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "timestamp": 1579716872.762535,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e2891075ec8e_42ab9a0a077f41056cf@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Marko Zivkovic, NC Opera Wants to Hear From You! [marko.zivkovicsrb@gmail.com]"
+                },
+                "attachments": [],
+                "size": 40672
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "id": "aLQHSxpFTL6Lf9L7xIqyiw"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 3.8785111904144287,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFTmqBa90rDNd4rg1BWoW5dOFgnuajZA==",
+                "key": "AgEFTmqBa90rDNd4rg1BWoW5dOFgnuajZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "timestamp": 1579716872.705416,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e2891015f154_42ab9a0a077f41047b6@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Susan Oller, NC Opera Wants to Hear From You! [doller@nc.rr.com]"
+                },
+                "attachments": [],
+                "size": 40631
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "id": "wH2Fti5tS4GcxiTvqRA7Hg"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 2.434997081756592,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFcDrHSKuuR5zZjxVCe6vUGqbzm1FTZA==",
+                "key": "AgEFcDrHSKuuR5zZjxVCe6vUGqbzm1FTZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "timestamp": 1579716872.563027,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "leonel.galan+sandbox@epifany.com",
+                  "message-id": "5e28910578de1_42ab9a0a077f41053b2@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Jo Murray, NC Opera Wants to Hear From You! [jocarolmurray@gmail.com]"
+                },
+                "attachments": [],
+                "size": 40656
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "fa0evS6WSb68gyPBhbtPgA"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579716872.399833,
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFVZ9qenFxX55AvQVBR7pep8lOe0wGZA==",
+                "key": "AgEFVZ9qenFxX55AvQVBR7pep8lOe0wGZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "id": "9_QokSy-QcO_yhzmu2x8Bw",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "leonel.galan+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "leonel.galan+sandbox@epifany.com",
+                  "message-id": "5e2890ff51da2_42ab9a0a077f4104489@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Andrea Mensch, NC Opera Wants to Hear From You! [kinnersna@gmail.com]"
+                },
+                "attachments": [],
+                "size": 40637
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "event": "delivered",
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "code": 250,
+                "description": "",
+                "session-seconds": 3.6946492195129395,
+                "utf8": true,
+                "attempt-no": 1,
+                "message": "OK",
+                "certificate-verified": true
+              }
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "delivery-status": {
+                "tls": true,
+                "mx-host": "aspmx.l.google.com",
+                "attempt-no": 1,
+                "description": "",
+                "session-seconds": 3.9692699909210205,
+                "utf8": true,
+                "code": 250,
+                "message": "OK",
+                "certificate-verified": true
+              },
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFVZ9qenFxX55AvQVBR7pep8lOe0wGZA==",
+                "key": "AgEFVZ9qenFxX55AvQVBR7pep8lOe0wGZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "delivered",
+              "campaigns": [],
+              "user-variables": {},
+              "flags": {
+                "is-routed": false,
+                "is-authenticated": true,
+                "is-system-test": false,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "timestamp": 1579716872.35743,
+              "envelope": {
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST",
+                "sending-ip": "198.61.254.22",
+                "targets": "lukas.barry+sandbox@epifany.com"
+              },
+              "message": {
+                "headers": {
+                  "to": "lukas.barry+sandbox@epifany.com",
+                  "message-id": "5e2890ff51da2_42ab9a0a077f4104489@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Andrea Mensch, NC Opera Wants to Hear From You! [kinnersna@gmail.com]"
+                },
+                "attachments": [],
+                "size": 40635
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "id": "gJD0BnASSAq03cHO6XtszQ"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579716872.3038182,
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFNUNZMGftxlXIQDJEN4LqKFWRI-_kZA==",
+                "key": "AgEFNUNZMGftxlXIQDJEN4LqKFWRI-_kZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "accepted",
+              "method": "http",
+              "user-variables": {},
+              "flags": {
+                "is-authenticated": true,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "envelope": {
+                "targets": "lukas.barry+sandbox@epifany.com",
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST"
+              },
+              "message": {
+                "headers": {
+                  "to": "%recipient%",
+                  "message-id": "5e2891081eb66_42ab9a0a077f41057f0@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Timothy Stammers, NC Opera Wants to Hear From You! [tomit613@gmail.com]"
+                },
+                "size": 37768
+              },
+              "recipient": "lukas.barry+sandbox@epifany.com",
+              "id": "mMiS5qniRXm2zZO7RQGyJA"
+            },
+            {
+              "tags": [
+                "OPERA Fill Survey"
+              ],
+              "timestamp": 1579716872.2886732,
+              "storage": {
+                "url": "https://se.api.mailgun.net/v3/domains/DOMAIN.TEST/messages/AgEFNUNZMGftxlXIQDJEN4LqKFWRI-_kZA==",
+                "key": "AgEFNUNZMGftxlXIQDJEN4LqKFWRI-_kZA=="
+              },
+              "recipient-domain": "epifany.com",
+              "event": "accepted",
+              "method": "http",
+              "user-variables": {},
+              "flags": {
+                "is-authenticated": true,
+                "is-test-mode": false
+              },
+              "log-level": "info",
+              "envelope": {
+                "targets": "leonel.galan+sandbox@epifany.com",
+                "transport": "smtp",
+                "sender": "postmaster@DOMAIN.TEST"
+              },
+              "message": {
+                "headers": {
+                  "to": "%recipient%",
+                  "message-id": "5e2891081eb66_42ab9a0a077f41057f0@9a8aefa4-d584-42c5-8d52-1adac175810d.mail",
+                  "from": "NC Opera - Pagliacci on 1/24 <no-reply@opera.mail.epifany.com>",
+                  "subject": "Timothy Stammers, NC Opera Wants to Hear From You! [tomit613@gmail.com]"
+                },
+                "size": 37768
+              },
+              "recipient": "leonel.galan+sandbox@epifany.com",
+              "id": "WhL6EJO-SHiyha1-zGyJiQ"
+            }
+          ],
+          "paging": {
+            "previous": "https://api.mailgun.net/v3/DOMAIN.TEST/events/WzMseyJiIjoiMjAyMC0wMi0wM1QxOTo1MTowOC40MzUrMDA6MDAiLCJlIjoiMjAyMC0wMS0wNFQxOTo1MTowOC40MzUrMDA6MDAifSx7ImIiOiIyMDIwLTAxLTI0VDExOjIwOjIzLjg2MyswMDowMCIsImUiOiIyMDIwLTAyLTAzVDE5OjUxOjA4LjQzNiswMDowMCJ9LCJfZG9jI2J0UXhUamVLUlFXVHAzSjJ2NGxNY2ciLFsicCIsImYiXSxudWxsLFtbImFjY291bnQuaWQiLCI1MDUwOGI4OTY5ZDdjNTMzZmUwMTJhMjgiXSxbImRvbWFpbi5uYW1lIiwidGVzdC1tYWlsLmVwaWZhbnkuY29tIl1dLDEwMF0=",
+            "first": "https://api.mailgun.net/v3/DOMAIN.TEST/events/WzMseyJiIjoiMjAyMC0wMi0wM1QxOTo1MTowOC40MzUrMDA6MDAiLCJlIjoiMjAyMC0wMS0wNFQxOTo1MTowOC40MzUrMDA6MDAifSx7ImIiOiIyMDIwLTAyLTAzVDE5OjUxOjA4LjQzNSswMDowMCIsImUiOiIyMDIwLTAxLTA0VDE5OjUxOjA4LjQzNSswMDowMCJ9LG51bGwsWyJmIl0sbnVsbCxbWyJhY2NvdW50LmlkIiwiNTA1MDhiODk2OWQ3YzUzM2ZlMDEyYTI4Il0sWyJkb21haW4ubmFtZSIsInRlc3QtbWFpbC5lcGlmYW55LmNvbSJdXSwxMDBd",
+            "last": "https://api.mailgun.net/v3/DOMAIN.TEST/events/WzMseyJiIjoiMjAyMC0wMi0wM1QxOTo1MTowOC40MzUrMDA6MDAiLCJlIjoiMjAyMC0wMS0wNFQxOTo1MTowOC40MzUrMDA6MDAifSx7ImIiOiIyMDIwLTAxLTA0VDE5OjUxOjA4LjQzNSswMDowMCIsImUiOiIyMDIwLTAyLTAzVDE5OjUxOjA4LjQzNSswMDowMCJ9LG51bGwsWyJwIiwiZiJdLG51bGwsW1siYWNjb3VudC5pZCIsIjUwNTA4Yjg5NjlkN2M1MzNmZTAxMmEyOCJdLFsiZG9tYWluLm5hbWUiLCJ0ZXN0LW1haWwuZXBpZmFueS5jb20iXV0sMTAwXQ==",
+            "next": "https://api.mailgun.net/v3/DOMAIN.TEST/events/WzMseyJiIjoiMjAyMC0wMi0wM1QxOTo1MTowOC40MzUrMDA6MDAiLCJlIjoiMjAyMC0wMS0wNFQxOTo1MTowOC40MzUrMDA6MDAifSx7ImIiOiIyMDIwLTAxLTIyVDE4OjE0OjMyLjI4OCswMDowMCIsImUiOiIyMDIwLTAxLTA0VDE5OjUxOjA4LjQzNSswMDowMCJ9LCJfZG9jI1doTDZFSk8tU0hpeWhhMS16R3lKaVEiLFsiZiJdLG51bGwsW1siYWNjb3VudC5pZCIsIjUwNTA4Yjg5NjlkN2M1MzNmZTAxMmEyOCJdLFsiZG9tYWluLm5hbWUiLCJ0ZXN0LW1haWwuZXBpZmFueS5jb20iXV0sMTAwXQ=="
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:09 GMT
 recorded_with: VCR 3.0.3

--- a/vcr_cassettes/exceptions.yml
+++ b/vcr_cassettes/exceptions.yml
@@ -42,4 +42,48 @@ http_interactions:
         }
     http_version: 
   recorded_at: Wed, 02 Nov 2016 19:43:40 GMT
+- request:
+    method: post
+    uri: https://api.mailgun.net/v3/not-our-doma.in/messages
+    body:
+      encoding: UTF-8
+      string: from=sally%40not-our-doma.in&to=bob%40DOMAIN.TEST&subject=Exception+Integration+Test&text=INTEGRATION+TESTING
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Length:
+      - '119'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:13 GMT
+      Server:
+      - nginx
+      Content-Length:
+      - '52'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "message": "Domain not found: not-our-doma.in"
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:13 GMT
 recorded_with: VCR 3.0.3

--- a/vcr_cassettes/list_members.yml
+++ b/vcr_cassettes/list_members.yml
@@ -317,4 +317,357 @@ http_interactions:
         }
     http_version: 
   recorded_at: Fri, 08 Jan 2016 20:20:45 GMT
-recorded_with: VCR 3.0.1
+- request:
+    method: post
+    uri: https://api.mailgun.net/v3/lists
+    body:
+      encoding: UTF-8
+      string: address=integration_test_list%40DOMAIN.TEST&name=Integration+Test+List&description=This+list+should+be+deleted+automatically.&access_level=members
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Length:
+      - '156'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:09 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '336'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "list": {
+            "access_level": "members",
+            "address": "integration_test_list@DOMAIN.TEST",
+            "created_at": "Mon, 03 Feb 2020 19:51:09 -0000",
+            "description": "This list should be deleted automatically.",
+            "members_count": 0,
+            "name": "Integration Test List"
+          },
+          "message": "Mailing list has been created"
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:09 GMT
+- request:
+    method: post
+    uri: https://api.mailgun.net/v3/lists/integration_test_list@DOMAIN.TEST/members
+    body:
+      encoding: UTF-8
+      string: address=integration_test_member_member%40DOMAIN.TEST&name=Jane+Doe&subscribed=true&upsert=no
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Length:
+      - '102'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:09 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '208'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "member": {
+            "address": "integration_test_member_member@DOMAIN.TEST",
+            "name": "Jane Doe",
+            "subscribed": true,
+            "vars": {}
+          },
+          "message": "Mailing list member has been created"
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:09 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/lists/integration_test_list@DOMAIN.TEST/members/integration_test_member_member@DOMAIN.TEST
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:09 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '155'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "member": {
+            "address": "integration_test_member_member@DOMAIN.TEST",
+            "name": "Jane Doe",
+            "subscribed": true,
+            "vars": {}
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:09 GMT
+- request:
+    method: put
+    uri: https://api.mailgun.net/v3/lists/integration_test_list@DOMAIN.TEST/members/integration_test_member_member@DOMAIN.TEST
+    body:
+      encoding: UTF-8
+      string: name=Jane+Doe+Update&subscribed=false
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Length:
+      - '37'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:10 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '216'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "member": {
+            "address": "integration_test_member_member@DOMAIN.TEST",
+            "name": "Jane Doe Update",
+            "subscribed": false,
+            "vars": {}
+          },
+          "message": "Mailing list member has been updated"
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:10 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/lists/integration_test_list@DOMAIN.TEST/members/integration_test_member_member@DOMAIN.TEST
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:11 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '144'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "member": {
+            "address": "integration_test_member_member@DOMAIN.TEST"
+          },
+          "message": "Mailing list member has been deleted"
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:11 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/lists/integration_test_list@DOMAIN.TEST
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:11 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "address": "integration_test_list@DOMAIN.TEST",
+          "message": "Mailing list has been removed"
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:11 GMT
+recorded_with: VCR 3.0.3

--- a/vcr_cassettes/mailing_list.yml
+++ b/vcr_cassettes/mailing_list.yml
@@ -387,4 +387,330 @@ http_interactions:
         }
     http_version: 
   recorded_at: Fri, 08 Jan 2016 20:23:03 GMT
-recorded_with: VCR 3.0.1
+- request:
+    method: post
+    uri: https://api.mailgun.net/v3/lists
+    body:
+      encoding: UTF-8
+      string: address=integration_test_list%40DOMAIN.TEST&name=Integration+Test+List&description=This+list+should+be+deleted+automatically.&access_level=members
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Length:
+      - '156'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:12 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '336'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "list": {
+            "access_level": "members",
+            "address": "integration_test_list@DOMAIN.TEST",
+            "created_at": "Mon, 03 Feb 2020 19:51:12 -0000",
+            "description": "This list should be deleted automatically.",
+            "members_count": 0,
+            "name": "Integration Test List"
+          },
+          "message": "Mailing list has been created"
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:12 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/lists/integration_test_list@DOMAIN.TEST
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:12 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '290'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "list": {
+            "access_level": "members",
+            "address": "integration_test_list@DOMAIN.TEST",
+            "created_at": "Mon, 03 Feb 2020 19:51:12 -0000",
+            "description": "This list should be deleted automatically.",
+            "members_count": 0,
+            "name": "Integration Test List"
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:12 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/lists?limit=50
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:12 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '1047'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "items": [
+            {
+              "access_level": "readonly",
+              "address": "elon@getstealz.mailgun.org",
+              "created_at": "Mon, 22 Sep 2014 14:14:21 -0000",
+              "description": "Elon",
+              "members_count": 0,
+              "name": "Elon"
+            },
+            {
+              "access_level": "members",
+              "address": "integration_test_list@DOMAIN.TEST",
+              "created_at": "Mon, 03 Feb 2020 19:51:12 -0000",
+              "description": "This list should be deleted automatically.",
+              "members_count": 0,
+              "name": "Integration Test List"
+            },
+            {
+              "access_level": "readonly",
+              "address": "ncsu_new@members.getstealz.com",
+              "created_at": "Fri, 26 Sep 2014 17:25:32 -0000",
+              "description": "All of our NCSU Users",
+              "members_count": 21410,
+              "name": "NCSU Users"
+            },
+            {
+              "access_level": "readonly",
+              "address": "testing@members.getstealz.com",
+              "created_at": "Mon, 29 Sep 2014 22:30:34 -0000",
+              "description": "Testing",
+              "members_count": 3,
+              "name": "test"
+            }
+          ],
+          "total_count": 4
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:12 GMT
+- request:
+    method: put
+    uri: https://api.mailgun.net/v3/lists/integration_test_list@DOMAIN.TEST
+    body:
+      encoding: UTF-8
+      string: address=integration_test_list%40DOMAIN.TEST&name=Integration+Test+List+Update&description=This+list+should+be+deleted+automatically.&access_level=readonly
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Length:
+      - '164'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:13 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '344'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "list": {
+            "access_level": "readonly",
+            "address": "integration_test_list@DOMAIN.TEST",
+            "created_at": "Mon, 03 Feb 2020 19:51:12 -0000",
+            "description": "This list should be deleted automatically.",
+            "members_count": 0,
+            "name": "Integration Test List Update"
+          },
+          "message": "Mailing list has been updated"
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:13 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/lists/integration_test_list@DOMAIN.TEST
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:13 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '108'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "address": "integration_test_list@DOMAIN.TEST",
+          "message": "Mailing list has been removed"
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:13 GMT
+recorded_with: VCR 3.0.3

--- a/vcr_cassettes/routes.yml
+++ b/vcr_cassettes/routes.yml
@@ -58,7 +58,7 @@ http_interactions:
             "priority": 10
           }
         }
-    http_version:
+    http_version: 
   recorded_at: Fri, 08 Jan 2016 20:08:19 GMT
 - request:
     method: get
@@ -136,7 +136,7 @@ http_interactions:
           ],
           "total_count": 3
         }
-    http_version:
+    http_version: 
   recorded_at: Fri, 08 Jan 2016 20:08:19 GMT
 - request:
     method: get
@@ -194,7 +194,7 @@ http_interactions:
           ],
           "total_count": 3
         }
-    http_version:
+    http_version: 
   recorded_at: Fri, 08 Jan 2016 20:08:19 GMT
 - request:
     method: get
@@ -249,7 +249,7 @@ http_interactions:
             "priority": 10
           }
         }
-    http_version:
+    http_version: 
   recorded_at: Fri, 08 Jan 2016 20:08:19 GMT
 - request:
     method: put
@@ -307,7 +307,7 @@ http_interactions:
           "message": "Route has been updated",
           "priority": 10
         }
-    http_version:
+    http_version: 
   recorded_at: Fri, 08 Jan 2016 20:08:19 GMT
 - request:
     method: delete
@@ -354,6 +354,378 @@ http_interactions:
           "id": "5690173212573000be30671e",
           "message": "Route has been deleted"
         }
-    http_version:
+    http_version: 
   recorded_at: Fri, 08 Jan 2016 20:08:20 GMT
-recorded_with: VCR 3.0.1
+- request:
+    method: post
+    uri: https://api.mailgun.net/v3/routes
+    body:
+      encoding: UTF-8
+      string: priority=10&description=Integration+Test+Route&expression=match_recipient%28%22alice%40DOMAIN.TEST%22%29&action=forward%28%22.*%40DOMAIN.TEST%22%29
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Length:
+      - '167'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:13 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '352'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "message": "Route has been created",
+          "route": {
+            "actions": [
+              "forward(\".*@DOMAIN.TEST\")"
+            ],
+            "created_at": "Mon, 03 Feb 2020 19:51:13 GMT",
+            "description": "Integration Test Route",
+            "expression": "match_recipient(\"alice@DOMAIN.TEST\")",
+            "id": "5e3879b1fafd1fd4e4111338",
+            "priority": 10
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:13 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/routes?limit=50
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:14 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '361'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "items": [
+            {
+              "actions": [
+                "forward(\".*@DOMAIN.TEST\")"
+              ],
+              "created_at": "Mon, 03 Feb 2020 19:51:13 GMT",
+              "description": "Integration Test Route",
+              "expression": "match_recipient(\"alice@DOMAIN.TEST\")",
+              "id": "5e3879b1fafd1fd4e4111338",
+              "priority": 10
+            }
+          ],
+          "total_count": 1
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:14 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/routes?limit=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:14 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '361'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "items": [
+            {
+              "actions": [
+                "forward(\".*@DOMAIN.TEST\")"
+              ],
+              "created_at": "Mon, 03 Feb 2020 19:51:13 GMT",
+              "description": "Integration Test Route",
+              "expression": "match_recipient(\"alice@DOMAIN.TEST\")",
+              "id": "5e3879b1fafd1fd4e4111338",
+              "priority": 10
+            }
+          ],
+          "total_count": 1
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:14 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/routes/5e3879b1fafd1fd4e4111338
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:14 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '313'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "route": {
+            "actions": [
+              "forward(\".*@DOMAIN.TEST\")"
+            ],
+            "created_at": "Mon, 03 Feb 2020 19:51:13 GMT",
+            "description": "Integration Test Route",
+            "expression": "match_recipient(\"alice@DOMAIN.TEST\")",
+            "id": "5e3879b1fafd1fd4e4111338",
+            "priority": 10
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:14 GMT
+- request:
+    method: put
+    uri: https://api.mailgun.net/v3/routes/5e3879b1fafd1fd4e4111338
+    body:
+      encoding: UTF-8
+      string: priority=10&description=Integration+Test+Route+Update&expression=match_recipient%28%22alice%40DOMAIN.TEST%22%29&action=forward%28%22.*%40DOMAIN.TEST%22%29
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Length:
+      - '174'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:14 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '326'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "actions": [
+            "forward(\".*@DOMAIN.TEST\")"
+          ],
+          "created_at": "Mon, 03 Feb 2020 19:51:13 GMT",
+          "description": "Integration Test Route Update",
+          "expression": "match_recipient(\"alice@DOMAIN.TEST\")",
+          "id": "5e3879b1fafd1fd4e4111338",
+          "message": "Route has been updated",
+          "priority": 10
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:14 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/routes/5e3879b1fafd1fd4e4111338
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:14 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "5e3879b1fafd1fd4e4111338",
+          "message": "Route has been deleted"
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:14 GMT
+recorded_with: VCR 3.0.3

--- a/vcr_cassettes/send_message.yml
+++ b/vcr_cassettes/send_message.yml
@@ -104,4 +104,73 @@ http_interactions:
         }
     http_version: 
   recorded_at: Thu, 07 Jan 2016 22:08:03 GMT
-recorded_with: VCR 3.0.1
+- request:
+    method: post
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/messages
+    body:
+      encoding: UTF-8
+      string: from=bob%40DOMAIN.TEST&to=sally%40DOMAIN.TEST&subject=Hash+Integration+Test&text=INTEGRATION+TESTING&o%3Atestmode=true
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Length:
+      - '138'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:13 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Ratelimit-Limit:
+      - '2000000'
+      X-Ratelimit-Remaining:
+      - '1999999'
+      X-Ratelimit-Reset:
+      - '1580759483701'
+      X-Recipient-Limit:
+      - '1000000'
+      X-Recipient-Remaining:
+      - '999999'
+      X-Recipient-Reset:
+      - '1580759483704'
+      Content-Length:
+      - '106'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "<20200203195113.1.FDA0A1513D20D741@DOMAIN.TEST>",
+          "message": "Queued. Thank you."
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:13 GMT
+recorded_with: VCR 3.0.3

--- a/vcr_cassettes/stats.yml
+++ b/vcr_cassettes/stats.yml
@@ -41,4 +41,44 @@ http_interactions:
       string: '{"items":[],"total_count":10000}'
     http_version: 
   recorded_at: Thu, 07 Jan 2016 22:08:06 GMT
-recorded_with: VCR 3.0.1
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/stats?event=sent&limit=50&skip=10
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:14 GMT
+      Server:
+      - nginx
+      Content-Length:
+      - '79'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"message":"this route was deprecated 2 years ago and is no longer
+        available"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:15 GMT
+recorded_with: VCR 3.0.3

--- a/vcr_cassettes/suppressions.yml
+++ b/vcr_cassettes/suppressions.yml
@@ -673,4 +673,765 @@ http_interactions:
         removed"}'
     http_version: 
   recorded_at: Wed, 30 Nov 2016 20:53:53 GMT
+- request:
+    method: post
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/bounces
+    body:
+      encoding: UTF-8
+      string: '[{"address":"test4@example.info","code":"500","error":"integration
+        testing"},{"address":"test3@example.net","code":"500","error":"integration
+        testing"},{"address":"test2@example.org","code":"500","error":"integration
+        testing"},{"address":"test1@example.com","code":"500","error":"integration
+        testing"}]'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '302'
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:15 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '63'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"message":"4 addresses have been added to the bounces table"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:15 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/bounces/test1@example.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:15 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"test1@example.com","message":"Bounced address has been
+        removed"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:15 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/bounces/test2@example.org
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:15 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"test2@example.org","message":"Bounced address has been
+        removed"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:15 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/bounces/test3@example.net
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:15 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"test3@example.net","message":"Bounced address has been
+        removed"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:15 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/bounces/test4@example.info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:16 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '78'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"test4@example.info","message":"Bounced address has been
+        removed"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:16 GMT
+- request:
+    method: post
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/unsubscribes
+    body:
+      encoding: UTF-8
+      string: '[{"address":"test4@example.info","tags":["integration"]},{"address":"test3@example.net","tags":["integration"]},{"address":"test2@example.org","tags":["integration"]},{"address":"test1@example.com","tags":["integration"]}]'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '222'
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:16 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '68'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"message":"4 addresses have been added to the unsubscribes table"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:16 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/unsubscribes/test1@example.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:16 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '79'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"test1@example.com","message":"Unsubscribe event has been
+        removed"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:16 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/unsubscribes/test2@example.org
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:16 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '79'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"test2@example.org","message":"Unsubscribe event has been
+        removed"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:16 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/unsubscribes/test3@example.net
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:16 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '79'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"test3@example.net","message":"Unsubscribe event has been
+        removed"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:16 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/unsubscribes/test4@example.info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:17 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '80'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"test4@example.info","message":"Unsubscribe event has been
+        removed"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:17 GMT
+- request:
+    method: post
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/complaints
+    body:
+      encoding: UTF-8
+      string: '[{"address":"test4@example.info"},{"address":"test3@example.net"},{"address":"test2@example.org"},{"address":"test1@example.com"}]'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '130'
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:17 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '76'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"message":"4 complaint addresses have been added to the complaints
+        table"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:17 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/complaints/test1@example.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:18 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '76'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"test1@example.com","message":"Spam complaint has been removed"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:18 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/complaints/test2@example.org
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:18 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '76'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"test2@example.org","message":"Spam complaint has been removed"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:18 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/complaints/test3@example.net
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:18 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '76'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"test3@example.net","message":"Spam complaint has been removed"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:18 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/complaints/test4@example.info
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:18 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '77'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"test4@example.info","message":"Spam complaint has been
+        removed"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:18 GMT
 recorded_with: VCR 3.0.3

--- a/vcr_cassettes/unsubscribes.yml
+++ b/vcr_cassettes/unsubscribes.yml
@@ -188,4 +188,211 @@ http_interactions:
         event has been removed"}'
     http_version: 
   recorded_at: Fri, 08 Jan 2016 18:55:28 GMT
-recorded_with: VCR 3.0.1
+- request:
+    method: post
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/unsubscribes
+    body:
+      encoding: UTF-8
+      string: address=integration-test-email%40DOMAIN.TEST&tag=*
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Length:
+      - '60'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:18 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '120'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"integration-test-email@DOMAIN.TEST","message":"Address
+        has been added to the unsubscribes table"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:18 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/unsubscribes/integration-test-email@DOMAIN.TEST
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:18 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '117'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"integration-test-email@DOMAIN.TEST","tags":["*"],"created_at":"Mon,
+        03 Feb 2020 19:51:18 UTC"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:18 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/unsubscribes
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:20 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '847'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"items":[{"address":"","tags":["*","Bar","Survey Requests"],"created_at":"Tue,
+        12 Feb 2019 18:26:14 UTC"},{"address":"bob@example.com","tags":["*","FOO"],"created_at":"Fri,
+        18 Jan 2019 19:39:23 UTC"},{"address":"integration-test-email@DOMAIN.TEST","tags":["*"],"created_at":"Mon,
+        03 Feb 2020 19:51:18 UTC"},{"address":"lukasbbarry@gmail.com","tags":["O2
+        Survey Response2"],"created_at":"Tue, 17 Sep 2019 21:07:11 UTC"}],"paging":{"first":"https://api.mailgun.net/v3/DOMAIN.TEST/unsubscribes?limit=100","last":"https://api.mailgun.net/v3/DOMAIN.TEST/unsubscribes?page=last&limit=100","next":"https://api.mailgun.net/v3/DOMAIN.TEST/unsubscribes?page=next&address=lukasbbarry%40gmail.com&limit=100","previous":"https://api.mailgun.net/v3/DOMAIN.TEST/unsubscribes?page=previous&address=&limit=100"}}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:20 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/DOMAIN.TEST/unsubscribes/integration-test-email@DOMAIN.TEST
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 03 Feb 2020 19:51:21 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '106'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"address":"integration-test-email@DOMAIN.TEST","message":"Unsubscribe
+        event has been removed"}
+
+        '
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:21 GMT
+recorded_with: VCR 3.0.3

--- a/vcr_cassettes/webhooks.yml
+++ b/vcr_cassettes/webhooks.yml
@@ -55,7 +55,7 @@ http_interactions:
             "url": "http://example.com/mailgun/events/bounce"
           }
         }
-    http_version:
+    http_version: 
   recorded_at: Fri, 08 Jan 2016 19:05:55 GMT
 - request:
     method: get
@@ -107,7 +107,7 @@ http_interactions:
             "url": "http://example.com/mailgun/events/bounce"
           }
         }
-    http_version:
+    http_version: 
   recorded_at: Fri, 08 Jan 2016 19:05:56 GMT
 - request:
     method: get
@@ -161,7 +161,7 @@ http_interactions:
             }
           }
         }
-    http_version:
+    http_version: 
   recorded_at: Fri, 08 Jan 2016 19:05:56 GMT
 - request:
     method: put
@@ -218,7 +218,7 @@ http_interactions:
             "url": "http://example.com/mailgun/events/bounceup"
           }
         }
-    http_version:
+    http_version: 
   recorded_at: Fri, 08 Jan 2016 19:05:56 GMT
 - request:
     method: delete
@@ -271,6 +271,289 @@ http_interactions:
             "url": "http://example.com/mailgun/events/bounceup"
           }
         }
-    http_version:
+    http_version: 
   recorded_at: Fri, 08 Jan 2016 19:05:57 GMT
-recorded_with: VCR 3.0.1
+- request:
+    method: post
+    uri: https://api.mailgun.net/v3/domains/DOMAIN.TEST/webhooks
+    body:
+      encoding: UTF-8
+      string: id=bounce&url=http%3A%2F%2Fexample.com%2Fmailgun%2Fevents%2Fbounce
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:21 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '117'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "message": "Webhook has been created",
+          "webhook": {
+            "url": "http://example.com/mailgun/events/bounce"
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:21 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/domains/DOMAIN.TEST/webhooks/bounce
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:21 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '76'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "webhook": {
+            "url": "http://example.com/mailgun/events/bounce"
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:21 GMT
+- request:
+    method: get
+    uri: https://api.mailgun.net/v3/domains/DOMAIN.TEST/webhooks
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:21 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '101'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "webhooks": {
+            "bounce": {
+              "url": "http://example.com/mailgun/events/bounce"
+            }
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:21 GMT
+- request:
+    method: put
+    uri: https://api.mailgun.net/v3/domains/DOMAIN.TEST/webhooks/bounce
+    body:
+      encoding: UTF-8
+      string: id=bounce&url=http%3A%2F%2Fexample.com%2Fmailgun%2Fevents%2Fbounceup
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Length:
+      - '68'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:21 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '119'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "message": "Webhook has been updated",
+          "webhook": {
+            "url": "http://example.com/mailgun/events/bounceup"
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:21 GMT
+- request:
+    method: delete
+    uri: https://api.mailgun.net/v3/domains/DOMAIN.TEST/webhooks/bounce
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Host:
+      - api.mailgun.net
+      Authorization:
+      - Basic YXBpOmtleS0xeGZvZGs4YzB3bTRlcHUyeTQ3b2E0d2JjZjQyNDBnOQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Disposition:
+      - inline
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 03 Feb 2020 19:51:22 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '119'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "message": "Webhook has been deleted",
+          "webhook": {
+            "url": "http://example.com/mailgun/events/bounceup"
+          }
+        }
+    http_version: 
+  recorded_at: Mon, 03 Feb 2020 19:51:22 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
# Fixes batch adding unsubscribes

### Closes #150 (Unsubscribe API returns Invalid JSON error)

I ran into the same error as AJMiller and wanted to submit a fix

The error in issue #150 is because when pulling a list of all unsubscribed, the `tag` key has an array value, so when the `create_unsubscribes` was calling `to_s` on any value that wasn't a string, it was doing so to an array, which was resulting in invalid JSON.

Rather than doing away with the entire block that converts to string, I added a condition checking for array, as it appears from the Mailgun docs that it can be either a singular string, in which case they give the key `tag`, or it can be an array, in which case they give the key `tags`.

See [Viewing a Single Unsubscribe](https://documentation.mailgun.com/en/latest/api-suppressions.html#view-a-single-unsubscribe) and [Add Multiple Unsubscribes](https://documentation.mailgun.com/en/latest/api-suppressions.html#add-multiple-unsubscribes)

So now if it is an array, we simply map all values in the array to a string:
```ruby
unsubscribe.each do |k, v|
  # Hash values MUST be strings.
  # However, unsubscribes contain an array of tags
  if v.is_a? Array
    unsubscribe[k] = v.map(&:to_s)
  elsif !v.is_a? String
    unsubscribe[k] = v.to_s
  end
end
```