### PR TITLE
Fixes batch adding unsubscribes (Issue #150)

### DIFF
--- a/lib/mailgun/suppressions.rb
+++ b/lib/mailgun/suppressions.rb
@@ -157,7 +157,10 @@ module Mailgun
 
         unsubscribe.each do |k, v|
           # Hash values MUST be strings.
-          if not v.is_a? String then
+          # However, unsubscribes contain an array of tags
+          if v.is_a? Array
+            unsubscribe[k] = v.map(&:to_s)
+          elsif !v.is_a? String
             unsubscribe[k] = v.to_s
           end
         end

--- a/spec/integration/suppressions_spec.rb
+++ b/spec/integration/suppressions_spec.rb
@@ -52,12 +52,29 @@ describe 'For the suppressions handling class', order: :defined, vcr: vcr_opts d
     end
   end
 
-  it 'can batch-add unsubscribes' do
+  it 'can batch-add unsubscribes with tags as string' do
     unsubscribes = []
     @addresses.each do |addr|
       unsubscribes.push({
         :address => addr,
         :tag => 'integration',
+      })
+    end
+
+    response, nested = @suppress.create_unsubscribes unsubscribes
+    response.to_h!
+
+    expect(response.code).to eq(200)
+    expect(response.body['message']).to eq('4 addresses have been added to the unsubscribes table')
+    expect(nested.length).to eq(0)
+  end
+
+  it 'can batch-add unsubscribes with tags as array' do
+    unsubscribes = []
+    @addresses.each do |addr|
+      unsubscribes.push({
+        :address => addr,
+        :tags => ['integration'],
       })
     end
 
@@ -123,4 +140,3 @@ describe 'For the suppressions handling class', order: :defined, vcr: vcr_opts d
 
   # TODO: Add tests for pagination support.
 end
-

--- a/vcr_cassettes/suppressions.yml
+++ b/vcr_cassettes/suppressions.yml
@@ -49,7 +49,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"message":"4 addresses have been added to the bounces table"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:49 GMT
 - request:
     method: delete
@@ -93,7 +93,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test1@example.com","message":"Bounced address has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:49 GMT
 - request:
     method: delete
@@ -137,7 +137,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test2@example.org","message":"Bounced address has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:50 GMT
 - request:
     method: delete
@@ -181,7 +181,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test3@example.net","message":"Bounced address has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:50 GMT
 - request:
     method: delete
@@ -225,7 +225,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test4@example.info","message":"Bounced address has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:50 GMT
 - request:
     method: post
@@ -274,7 +274,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"message":"4 addresses have been added to the unsubscribes table"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:51 GMT
 - request:
     method: delete
@@ -318,7 +318,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test1@example.com","message":"Unsubscribe event has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:51 GMT
 - request:
     method: delete
@@ -362,7 +362,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test2@example.org","message":"Unsubscribe event has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:51 GMT
 - request:
     method: delete
@@ -406,7 +406,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test3@example.net","message":"Unsubscribe event has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:51 GMT
 - request:
     method: delete
@@ -450,7 +450,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test4@example.info","message":"Unsubscribe event has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:52 GMT
 - request:
     method: post
@@ -498,7 +498,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"message":"4 complaint addresses have been added to the complaints
         table"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:52 GMT
 - request:
     method: delete
@@ -541,7 +541,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"address":"test1@example.com","message":"Spam complaint has been removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:52 GMT
 - request:
     method: delete
@@ -584,7 +584,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"address":"test2@example.org","message":"Spam complaint has been removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:52 GMT
 - request:
     method: delete
@@ -627,7 +627,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"address":"test3@example.net","message":"Spam complaint has been removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:53 GMT
 - request:
     method: delete
@@ -671,6 +671,57 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test4@example.info","message":"Spam complaint has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:53 GMT
+- request:
+    method: post
+    uri: https://api:<APIKEY>@api.mailgun.net/v3/DOMAIN.TEST/unsubscribes
+    body:
+      encoding: UTF-8
+      string: '[{"address":"test4@example.info","tag":"integration"},{"address":"test3@example.net","tag":"integration"},{"address":"test2@example.org","tag":"integration"},{"address":"test1@example.com","tag":"integration"}]'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '210'
+      Host:
+      - api.mailgun.net
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 15:16:07 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '68'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"message":"4 addresses have been added to the unsubscribes table"}
+
+        '
+    http_version:
+  recorded_at: Tue, 04 Feb 2020 15:16:07 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
# Fixes batch adding unsubscribes

### Closes #150 (Unsubscribe API returns Invalid JSON error)

I ran into the same error as AJMiller and wanted to submit a fix

The error in issue #150 is because when pulling a list of all unsubscribed, the `tag` key has an array value, so when the `create_unsubscribes` was calling `to_s` on any value that wasn't a string, it was doing so to an array, which was resulting in invalid JSON.

Rather than doing away with the entire block that converts to string, I added a condition checking for array, as it appears from the Mailgun docs that it can be either a singular string, in which case they give the key `tag`, or it can be an array, in which case they give the key `tags`.

See [Viewing a Single Unsubscribe](https://documentation.mailgun.com/en/latest/api-suppressions.html#view-a-single-unsubscribe) and [Add Multiple Unsubscribes](https://documentation.mailgun.com/en/latest/api-suppressions.html#add-multiple-unsubscribes)

So now if it is an array, we simply map all values in the array to a string:
```ruby
unsubscribe.each do |k, v|
  # Hash values MUST be strings.
  # However, unsubscribes contain an array of tags
  if v.is_a? Array
    unsubscribe[k] = v.map(&:to_s)
  elsif !v.is_a? String
    unsubscribe[k] = v.to_s
  end
end
```