### PR TITLE
Relax version constraint on rest-client

### DIFF
--- a/mailgun.gemspec
+++ b/mailgun.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'vcr', '~> 3.0.3'
   spec.add_development_dependency 'simplecov', '~> 0.16.1'
   spec.add_development_dependency 'rails'
-  spec.add_dependency 'rest-client', '~> 2.0.2'
+  spec.add_dependency 'rest-client', '>= 2.0.2'
 
 end


### PR DESCRIPTION
Fix https://github.com/mailgun/mailgun-ruby/issues/176