### PR TITLE
Add support for AMP HTML

### DIFF
--- a/lib/mailgun/messages/message_builder.rb
+++ b/lib/mailgun/messages/message_builder.rb
@@ -115,6 +115,14 @@ module Mailgun
       body_html(html_body)
     end
 
+    # Set an AMP part for the message object
+    #
+    # @param [String] amp The AMP HTML for the email.
+    # @return [void]
+    def amp_html(amp = nil)
+      set_multi_simple('amp-html', amp)
+    end
+
     # Adds a series of attachments, when called upon.
     #
     # @param [String|File] attachment A file object for attaching as an attachment.

--- a/lib/mailgun/messages/message_builder.rb
+++ b/lib/mailgun/messages/message_builder.rb
@@ -120,7 +120,7 @@ module Mailgun
     # @param [String] amp The AMP HTML for the email.
     # @return [void]
     def amp_html(amp = nil)
-      set_multi_simple('amp-html', amp)
+      set_single('amp-html', amp)
     end
 
     # Adds a series of attachments, when called upon.

--- a/spec/unit/messages/message_builder_spec.rb
+++ b/spec/unit/messages/message_builder_spec.rb
@@ -176,6 +176,17 @@ describe 'The method body_text' do
   end
 end
 
+describe 'The method amp_html' do
+  it 'sets amp-html to a string, not an array' do
+    the_text = 'Don\'t mess with Texas!'
+    @mb_obj = Mailgun::MessageBuilder.new
+    @mb_obj.amp_html(the_text)
+    expect(@mb_obj.message['amp-html']).to be_a(String)
+    expect(@mb_obj.message['amp-html']).to eq(the_text)
+  end
+end
+    
+
 describe 'The method set_from_address' do
   it 'warns of set_from_address deprecation' do
     @mb_obj = Mailgun::MessageBuilder.new

--- a/spec/unit/railgun/content_type_spec.rb
+++ b/spec/unit/railgun/content_type_spec.rb
@@ -26,6 +26,17 @@ describe 'extract_body' do
   }
   let(:html_content) { '<h3> [TEST] </h3> <br/> Hello, world!' }
 
+  let(:amp_mail_option) {
+    {
+      from:        'bob@example.com',
+      to:          'sally@example.com',
+      subject:     'RAILGUN TEST SAMPLE',
+      body:         amp_content,
+      content_type: 'text/x-amp-html',
+    }
+  }
+  let(:amp_content) { '<h3> [TEST] </h3> <br/> Hello from AMP!' }
+
   context 'with <Content-Type: text/plain>' do
     let(:sample_mail) { Mail.new(text_mail_option) }
 
@@ -53,10 +64,12 @@ describe 'extract_body' do
   context 'with <Content-Type: multipart/alternative>' do
     let(:text_mail) { Mail.new(text_mail_option) }
     let(:html_mail) { Mail.new(html_mail_option) }
+    let(:amp_mail) { Mail.new(amp_mail_option) }
 
     before do
       @sample_mail = Mail::Part.new(content_type: "multipart/alternative")
       @sample_mail.add_part text_mail
+      @sample_mail.add_part amp_mail
       @sample_mail.add_part html_mail
     end
 
@@ -66,6 +79,10 @@ describe 'extract_body' do
 
     it 'should return body html' do
       expect(Railgun.extract_body_html(@sample_mail)).to eq(html_content)
+    end
+
+    it 'should return AMP html' do
+      expect(Railgun.extract_amp_html(@sample_mail)).to eq(amp_content)
     end
   end
 end


### PR DESCRIPTION
This PR adds support for the `amp-html` parameter in `Mailgun::MessageBuilder` and Railgun. This allows users to send AMP emails in two ways:

1. Calling `amp_html` on a `Mailgun::MessageBuilder` instance
2. Sending a multipart email with a `text/x-amp-html` part in a Rails mailer