### PR TITLE
Adds option for template config

### DIFF
--- a/lib/mailgun/messages/message_builder.rb
+++ b/lib/mailgun/messages/message_builder.rb
@@ -260,6 +260,18 @@ module Mailgun
       header name, data
     end
 
+    # Send email by a template. Note that this is NOT used for template variables, but
+    # rather for the Templating feature (check Sending->Templates)
+    #
+    # @param [String] tag A defined template name to use. Passing nil or
+    #   empty string will delete template key and value from @message hash.
+    # @return [void]
+    def template(template_name = nil)
+      key = 'template'
+      return @message.delete(key) if template_name.to_s.empty?
+      set_single(key, template_name)
+    end
+
     # Attaches custom JSON data to the message. See the following doc page for more info.
     # https://documentation.mailgun.com/user_manual.html#attaching-data-to-messages
     #

--- a/lib/mailgun/version.rb
+++ b/lib/mailgun/version.rb
@@ -1,4 +1,4 @@
 # It's the version. Yeay!
 module Mailgun
-  VERSION = '1.2.0'
+  VERSION = '1.3.0'
 end

--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -11,7 +11,7 @@ module Railgun
   class Mailer
 
     # List of the headers that will be ignored when copying headers from `mail.header_fields`
-    IGNORED_HEADERS = %w[ to from subject reply-to ]
+    IGNORED_HEADERS = %w[ to from subject reply-to template ]
 
     # [Hash] config ->
     #   Requires *at least* `api_key` and `domain` keys.
@@ -152,6 +152,7 @@ module Railgun
     mb.from mail[:from]
     mb.reply_to(mail[:reply_to].to_s) if mail[:reply_to].present?
     mb.subject mail.subject
+    mb.template(mail.mailgun_template) if mail.mailgun_template.present?
     mb.body_html extract_body_html(mail)
     mb.body_text extract_body_text(mail)
 

--- a/lib/railgun/message.rb
+++ b/lib/railgun/message.rb
@@ -11,7 +11,8 @@ module Mail
     attr_accessor :mailgun_variables,
                   :mailgun_options,
                   :mailgun_recipient_variables,
-                  :mailgun_headers
+                  :mailgun_headers,
+                  :mailgun_template
 
   end
 end

--- a/spec/unit/messages/message_builder_spec.rb
+++ b/spec/unit/messages/message_builder_spec.rb
@@ -530,6 +530,34 @@ describe 'The method header' do
   end
 end
 
+describe 'The method template' do
+  before(:each) do
+    @mb_obj = Mailgun::MessageBuilder.new
+  end
+
+  it 'unsets the message template if called and no parameters are provided' do
+    @mb_obj.template
+
+    expect(@mb_obj.message['template']).to be_empty
+  end
+
+  it 'sets the message template if called with the template_name parameter' do
+    template_name = 'template.test'
+    @mb_obj.template(template_name)
+
+    expect(@mb_obj.message['template']).to eq(template_name)
+  end
+
+  it 'ensures no duplicate templates can exist and last setter is stored' do
+    first_template_name = 'template.test'
+    second_template_name = 'template.second_test'
+    @mb_obj.template(first_template_name)
+    @mb_obj.template(second_template_name)
+
+    expect(@mb_obj.message['template']).to eq(second_template_name)
+  end
+end
+
 describe 'The method variable' do
   before(:each) do
     @mb_obj = Mailgun::MessageBuilder.new


### PR DESCRIPTION
Fix for #166 with slightly different approach to #168 
Uses the `tap` block to set both the template and variables.

```ruby
mail(to: 'user@example.com', subject: 'Subject here', body: '').tap do |message|
  message.mailgun_template = 'mg-template-name'
  message.mailgun_headers = {
    'X-Mailgun-Variables': JSON.generate({
      mg_var1: @var1,
      mg_var2: @var2
    })
  }
end
```

Also note `body` being set to an empty string to bypass Rails templating.