### PR TITLE
Update webhooks

### DIFF
--- a/lib/mailgun/webhooks/webhooks.rb
+++ b/lib/mailgun/webhooks/webhooks.rb
@@ -3,7 +3,6 @@ module Mailgun
   # A Mailgun::Webhooks object is a simple CRUD interface to Mailgun Webhooks.
   # Uses Mailgun
   class Webhooks
-
     # Public creates a new Mailgun::Webhooks instance.
     #   Defaults to Mailgun::Client
     def initialize(client = Mailgun::Client.new)
@@ -58,7 +57,7 @@ module Mailgun
     #
     # Returns true or false
     def create_all(domain, url = '')
-      %w(bounce click deliver drop open spam unsubscribe).each do |action|
+      %w(clicked complained delivered opened permanent_fail temporary_fail unsubscribed).each do |action|
         add_webhook domain, action, url
       end
       true
@@ -90,7 +89,7 @@ module Mailgun
     # Returns a Boolean on the success
     def remove_all(domain)
       fail Mailgun::ParameterError('Domain not provided to remove webhooks from') unless domain
-      %w(bounce click deliver drop open spam unsubscribe).each do |action|
+      %w(clicked complained delivered opened permanent_fail temporary_fail unsubscribed).each do |action|
         delete_webhook domain, action
       end
     end

--- a/lib/mailgun/webhooks/webhooks.rb
+++ b/lib/mailgun/webhooks/webhooks.rb
@@ -3,6 +3,7 @@ module Mailgun
   # A Mailgun::Webhooks object is a simple CRUD interface to Mailgun Webhooks.
   # Uses Mailgun
   class Webhooks
+    WEBHOOKS_ACTIONS = %w(clicked complained delivered opened permanent_fail temporary_fail unsubscribed).freeze
     # Public creates a new Mailgun::Webhooks instance.
     #   Defaults to Mailgun::Client
     def initialize(client = Mailgun::Client.new)
@@ -57,7 +58,7 @@ module Mailgun
     #
     # Returns true or false
     def create_all(domain, url = '')
-      %w(clicked complained delivered opened permanent_fail temporary_fail unsubscribed).each do |action|
+      WEBHOOKS_ACTIONS.each do |action|
         add_webhook domain, action, url
       end
       true
@@ -89,7 +90,7 @@ module Mailgun
     # Returns a Boolean on the success
     def remove_all(domain)
       fail Mailgun::ParameterError('Domain not provided to remove webhooks from') unless domain
-      %w(clicked complained delivered opened permanent_fail temporary_fail unsubscribed).each do |action|
+      WEBHOOKS_ACTIONS.each do |action|
         delete_webhook domain, action
       end
     end


### PR DESCRIPTION
When we ran the create_all and remove_all it did so with legacy webhooks. 

This PR updates the naming and DRYs up the names into a constant.

The unit tests are green, but couldn't get the integration tests to run, even after updating our API info.