### PR TITLE
Disable body when template is set

### DIFF
--- a/lib/mailgun/client.rb
+++ b/lib/mailgun/client.rb
@@ -10,6 +10,8 @@ module Mailgun
   # See the Github documentation for full examples.
   class Client
 
+    attr_reader :http_client
+
     def initialize(api_key = Mailgun.api_key,
                    api_host = 'api.mailgun.net',
                    api_version = 'v3',

--- a/lib/mailgun/messages/message_builder.rb
+++ b/lib/mailgun/messages/message_builder.rb
@@ -260,6 +260,18 @@ module Mailgun
       header name, data
     end
 
+    # Send email by a template. Note that this is NOT used for template variables, but
+    # rather for the Templating feature (check Sending->Templates)
+    #
+    # @param [String] tag A defined template name to use. Passing nil or
+    #   empty string will delete template key and value from @message hash.
+    # @return [void]
+    def template(template_name = nil)
+      key = 'template'
+      return @message.delete(key) if template_name.to_s.empty?
+      set_single(key, template_name)
+    end
+
     # Attaches custom JSON data to the message. See the following doc page for more info.
     # https://documentation.mailgun.com/user_manual.html#attaching-data-to-messages
     #

--- a/lib/mailgun/messages/message_builder.rb
+++ b/lib/mailgun/messages/message_builder.rb
@@ -276,13 +276,11 @@ module Mailgun
     # https://documentation.mailgun.com/user_manual.html#attaching-data-to-messages
     #
     # @param [String] name A name for the custom variable block.
-    # @param [String|Hash] data Either a string or a hash. If it is not valid JSON or
-    #                           can not be converted to JSON, ParameterError will be raised.
+    # @param [String] data Variable value.
     # @return [void]
     def variable(name, data)
       fail(Mailgun::ParameterError, 'Variable name must be specified') if name.to_s.empty?
-      jsondata = make_json data
-      set_single("v:#{name}", jsondata)
+      set_single("v:#{name}", data.is_a?(Hash) ? data.to_json : data.to_s)
     end
 
     # Add custom parameter to the message. A custom parameter is any parameter that
@@ -399,7 +397,7 @@ module Mailgun
         full_name = vars['full_name']
       elsif vars['first'] || vars['last']
         full_name = "#{vars['first']} #{vars['last']}".strip
-      end 
+      end
 
       return "'#{full_name}' <#{address}>" if defined?(full_name)
       address

--- a/lib/mailgun/suppressions.rb
+++ b/lib/mailgun/suppressions.rb
@@ -157,7 +157,10 @@ module Mailgun
 
         unsubscribe.each do |k, v|
           # Hash values MUST be strings.
-          if not v.is_a? String then
+          # However, unsubscribes contain an array of tags
+          if v.is_a? Array
+            unsubscribe[k] = v.map(&:to_s)
+          elsif !v.is_a? String
             unsubscribe[k] = v.to_s
           end
         end

--- a/lib/mailgun/version.rb
+++ b/lib/mailgun/version.rb
@@ -1,4 +1,4 @@
 # It's the version. Yeay!
 module Mailgun
-  VERSION = '1.2.0'
+  VERSION = '1.3.0'
 end

--- a/lib/mailgun/webhooks/webhooks.rb
+++ b/lib/mailgun/webhooks/webhooks.rb
@@ -3,7 +3,7 @@ module Mailgun
   # A Mailgun::Webhooks object is a simple CRUD interface to Mailgun Webhooks.
   # Uses Mailgun
   class Webhooks
-
+    WEBHOOKS_ACTIONS = %w(clicked complained delivered opened permanent_fail temporary_fail unsubscribed).freeze
     # Public creates a new Mailgun::Webhooks instance.
     #   Defaults to Mailgun::Client
     def initialize(client = Mailgun::Client.new)
@@ -58,7 +58,7 @@ module Mailgun
     #
     # Returns true or false
     def create_all(domain, url = '')
-      %w(bounce click deliver drop open spam unsubscribe).each do |action|
+      WEBHOOKS_ACTIONS.each do |action|
         add_webhook domain, action, url
       end
       true
@@ -90,7 +90,7 @@ module Mailgun
     # Returns a Boolean on the success
     def remove_all(domain)
       fail Mailgun::ParameterError('Domain not provided to remove webhooks from') unless domain
-      %w(bounce click deliver drop open spam unsubscribe).each do |action|
+      WEBHOOKS_ACTIONS.each do |action|
         delete_webhook domain, action
       end
     end

--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -11,7 +11,7 @@ module Railgun
   class Mailer
 
     # List of the headers that will be ignored when copying headers from `mail.header_fields`
-    IGNORED_HEADERS = %w[ to from subject reply-to template ]
+    IGNORED_HEADERS = %w[ to from subject reply-to template mime-version]
 
     # [Hash] config ->
     #   Requires *at least* `api_key` and `domain` keys.
@@ -46,9 +46,12 @@ module Railgun
 
     def deliver!(mail)
       mg_message = Railgun.transform_for_mailgun(mail)
-      response = @mg_client.send_message(@domain, mg_message)
 
-      if response.code == 200 then
+      domain = mail.mailgun_domain || @domain # get the domain from the current message or from config
+
+      response = @mg_client.send_message(domain, mg_message)
+
+      if response.code == 200
         mg_id = response.to_h['id']
         mail.message_id = mg_id
       end

--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -40,7 +40,7 @@ module Railgun
     def domain_config(domain = nil)
       domain_config = DEFAULT_CONFIG.merge(@config.except(:domains))
 
-      if domain && @config[:domains][domain]
+      if domain && @config[:domains] && @config[:domains][domain]
         domain_config.merge(@config[:domains][domain])
       else
         domain_config
@@ -75,7 +75,7 @@ module Railgun
     def deliver!(mail)
       mg_message = Railgun.transform_for_mailgun(mail)
 
-      domain = mail.mailgun_domain || @domain # get the domain from the current message or from config
+      domain = mail.mailgun_domain || @config[:domain] # get the domain from the current message or from config
 
       response = mailgun_client(domain).send_message(domain, mg_message)
 

--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -32,6 +32,8 @@ module Railgun
         config[:api_host] || 'api.mailgun.net',
         config[:api_version] || 'v3',
         config[:api_ssl].nil? ? true : config[:api_ssl],
+        config[:api_test_mode] || false,
+        config[:api_timeout]
       )
       @domain = @config[:domain]
 

--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -11,7 +11,7 @@ module Railgun
   class Mailer
 
     # List of the headers that will be ignored when copying headers from `mail.header_fields`
-    IGNORED_HEADERS = %w[ to from subject reply-to ]
+    IGNORED_HEADERS = %w[ to from subject reply-to template ]
 
     # [Hash] config ->
     #   Requires *at least* `api_key` and `domain` keys.
@@ -152,6 +152,7 @@ module Railgun
     mb.from mail[:from]
     mb.reply_to(mail[:reply_to].to_s) if mail[:reply_to].present?
     mb.subject mail.subject
+    mb.template(mail.mailgun_template) if mail.mailgun_template.present?
     mb.body_html extract_body_html(mail)
     mb.body_text extract_body_text(mail)
 

--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -75,7 +75,7 @@ module Railgun
     def deliver!(mail)
       mg_message = Railgun.transform_for_mailgun(mail)
 
-      domain = mail.mailgun_domain || @config[:domain] # get the domain from the current messte or from config
+      domain = mail.mailgun_domain || @config[:domain] # get the domain from the current message or from config
 
       response = mailgun_client(domain).send_message(domain, mg_message)
 

--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -75,7 +75,7 @@ module Railgun
     def deliver!(mail)
       mg_message = Railgun.transform_for_mailgun(mail)
 
-      domain = mail.mailgun_domain || @config[:domain] # get the domain from the current message or from config
+      domain = mail.mailgun_domain || @config[:domain] # get the domain from the current messte or from config
 
       response = mailgun_client(domain).send_message(domain, mg_message)
 
@@ -176,9 +176,13 @@ module Railgun
     mb.from mail[:from]
     mb.reply_to(mail[:reply_to].to_s) if mail[:reply_to].present?
     mb.subject mail.subject
-    mb.template(mail.mailgun_template) if mail.mailgun_template.present?
-    mb.body_html extract_body_html(mail)
-    mb.body_text extract_body_text(mail)
+
+    if mail.mailgun_template
+      mb.template(mail.mailgun_template)
+    else
+      mb.body_html extract_body_html(mail)
+      mb.body_text extract_body_text(mail)
+    end
 
     [:to, :cc, :bcc].each do |rcpt_type|
       addrs = mail[rcpt_type] || nil

--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -81,11 +81,6 @@ module Railgun
   def transform_for_mailgun(mail)
     message = build_message_object(mail)
 
-    # v:* attributes (variables)
-    mail.mailgun_variables.try(:each) do |k, v|
-      message["v:#{k}"] = JSON.dump(v)
-    end
-
     # o:* attributes (options)
     mail.mailgun_options.try(:each) do |k, v|
       message["o:#{k}"] = v
@@ -131,6 +126,9 @@ module Railgun
 
     # recipient variables
     message['recipient-variables'] = mail.mailgun_recipient_variables.to_json if mail.mailgun_recipient_variables
+
+    # recipient variables
+    message['h:X-Mailgun-Variables'] = mail.mailgun_variables.to_json if mail.mailgun_variables
 
     # reject blank values
     message.delete_if do |k, v|

--- a/lib/railgun/message.rb
+++ b/lib/railgun/message.rb
@@ -11,7 +11,8 @@ module Mail
     attr_accessor :mailgun_variables,
                   :mailgun_options,
                   :mailgun_recipient_variables,
-                  :mailgun_headers
+                  :mailgun_headers,
+                  :mailgun_template
 
   end
 end

--- a/lib/railgun/message.rb
+++ b/lib/railgun/message.rb
@@ -12,7 +12,8 @@ module Mail
                   :mailgun_options,
                   :mailgun_recipient_variables,
                   :mailgun_headers,
-                  :mailgun_template
+                  :mailgun_template,
+                  :mailgun_domain
 
   end
 end

--- a/lib/railgun/railtie.rb
+++ b/lib/railgun/railtie.rb
@@ -2,11 +2,8 @@ require 'railgun/mailer'
 
 module Railgun
   class Railtie < ::Rails::Railtie
-    initializer "railgun.configure_rails_initialization" do
-      ActiveSupport.on_load(:action_mailer) do
-        add_delivery_method :mailgun, Railgun::Mailer
-        ActiveSupport.run_load_hooks(:mailgun_mailer, Railgun::Mailer)
-      end
+    initializer "railgun.configure_rails_initialization", before: 'action_mailer.set_configs' do
+      ActionMailer::Base.add_delivery_method(:mailgun, Railgun::Mailer)
     end
   end
 end

--- a/lib/railgun/railtie.rb
+++ b/lib/railgun/railtie.rb
@@ -2,8 +2,11 @@ require 'railgun/mailer'
 
 module Railgun
   class Railtie < ::Rails::Railtie
-    config.before_configuration do
-      ActionMailer::Base.add_delivery_method :mailgun, Railgun::Mailer
+    initializer "railgun.configure_rails_initialization" do
+      ActiveSupport.on_load(:action_mailer) do
+        add_delivery_method :mailgun, Railgun::Mailer
+        ActiveSupport.run_load_hooks(:mailgun_mailer, Railgun::Mailer)
+      end
     end
   end
 end

--- a/spec/integration/suppressions_spec.rb
+++ b/spec/integration/suppressions_spec.rb
@@ -52,12 +52,29 @@ describe 'For the suppressions handling class', order: :defined, vcr: vcr_opts d
     end
   end
 
-  it 'can batch-add unsubscribes' do
+  it 'can batch-add unsubscribes with tags as string' do
     unsubscribes = []
     @addresses.each do |addr|
       unsubscribes.push({
         :address => addr,
         :tag => 'integration',
+      })
+    end
+
+    response, nested = @suppress.create_unsubscribes unsubscribes
+    response.to_h!
+
+    expect(response.code).to eq(200)
+    expect(response.body['message']).to eq('4 addresses have been added to the unsubscribes table')
+    expect(nested.length).to eq(0)
+  end
+
+  it 'can batch-add unsubscribes with tags as array' do
+    unsubscribes = []
+    @addresses.each do |addr|
+      unsubscribes.push({
+        :address => addr,
+        :tags => ['integration'],
       })
     end
 
@@ -123,4 +140,3 @@ describe 'For the suppressions handling class', order: :defined, vcr: vcr_opts d
 
   # TODO: Add tests for pagination support.
 end
-

--- a/spec/unit/messages/message_builder_spec.rb
+++ b/spec/unit/messages/message_builder_spec.rb
@@ -530,6 +530,34 @@ describe 'The method header' do
   end
 end
 
+describe 'The method template' do
+  before(:each) do
+    @mb_obj = Mailgun::MessageBuilder.new
+  end
+
+  it 'unsets the message template if called and no parameters are provided' do
+    @mb_obj.template
+
+    expect(@mb_obj.message['template']).to be_empty
+  end
+
+  it 'sets the message template if called with the template_name parameter' do
+    template_name = 'template.test'
+    @mb_obj.template(template_name)
+
+    expect(@mb_obj.message['template']).to eq(template_name)
+  end
+
+  it 'ensures no duplicate templates can exist and last setter is stored' do
+    first_template_name = 'template.test'
+    second_template_name = 'template.second_test'
+    @mb_obj.template(first_template_name)
+    @mb_obj.template(second_template_name)
+
+    expect(@mb_obj.message['template']).to eq(second_template_name)
+  end
+end
+
 describe 'The method variable' do
   before(:each) do
     @mb_obj = Mailgun::MessageBuilder.new

--- a/spec/unit/messages/message_builder_spec.rb
+++ b/spec/unit/messages/message_builder_spec.rb
@@ -562,22 +562,19 @@ describe 'The method variable' do
   before(:each) do
     @mb_obj = Mailgun::MessageBuilder.new
   end
-  it 'accepts valid JSON and stores it as message[param].' do
-    @mb_obj.variable('my-data', '{"key":"value"}')
 
-    expect(@mb_obj.message["v:my-data"]).to be_kind_of(String)
-    expect(@mb_obj.message["v:my-data"].to_s).to eq('{"key":"value"}')
-  end
-  it 'accepts a hash and appends as data to the message.' do
-    data = {'key' => 'value'}
-    @mb_obj.variable('my-data', data)
+  {
+    42           => '42',
+    nil          => '',
+    'foo'        => 'foo',
+    {foo: 'bar'} => '{"foo":"bar"}'
+  }.each do |input, output|
+    it 'accepts any value and stores its string form as message[param].' do
+      @mb_obj.variable('my-data', input)
 
-    expect(@mb_obj.message["v:my-data"]).to be_kind_of(String)
-    expect(@mb_obj.message["v:my-data"].to_s).to eq('{"key":"value"}')
-  end
-  it 'throws an exception on broken JSON.' do
-    data = 'This is some crappy JSON.'
-    expect {@mb_obj.variable('my-data', data)}.to raise_error(Mailgun::ParameterError)
+      expect(@mb_obj.message["v:my-data"]).to be_kind_of(String)
+      expect(@mb_obj.message["v:my-data"].to_s).to eq(output)
+    end
   end
 end
 

--- a/spec/unit/railgun/mailer_spec.rb
+++ b/spec/unit/railgun/mailer_spec.rb
@@ -81,19 +81,19 @@ describe 'Railgun::Mailer' do
 
   it 'adds variables to message body' do
     message = UnitTestMailer.plain_message('test@example.org', '', {})
-    message.mailgun_variables ||= {
-      'user' => {:id => '1', :name => 'tstark'},
-    }
 
+    mailgun_variables =  { 'user' => {:id => '1', :name => 'tstark'} }
+
+    message.mailgun_variables ||= mailgun_variables
+    
     body = Railgun.transform_for_mailgun(message)
 
-    expect(body).to include('v:user')
+    expect(body).to include('h:X-Mailgun-Variables')
 
-    var_body = JSON.load(body['v:user'])
-    expect(var_body).to include('id')
-    expect(var_body).to include('name')
-    expect(var_body['id']).to eq('1')
-    expect(var_body['name']).to eq('tstark')
+    var_body = JSON.load(body['h:X-Mailgun-Variables'])
+    expect(var_body['user']['id']).to eq('1')
+    expect(var_body['user']['name']).to eq('tstark')
+    expect(var_body).to eq(JSON.parse(JSON.dump(mailgun_variables)))
   end
 
   it 'adds headers to message body' do

--- a/vcr_cassettes/suppressions.yml
+++ b/vcr_cassettes/suppressions.yml
@@ -49,7 +49,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"message":"4 addresses have been added to the bounces table"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:49 GMT
 - request:
     method: delete
@@ -93,7 +93,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test1@example.com","message":"Bounced address has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:49 GMT
 - request:
     method: delete
@@ -137,7 +137,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test2@example.org","message":"Bounced address has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:50 GMT
 - request:
     method: delete
@@ -181,7 +181,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test3@example.net","message":"Bounced address has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:50 GMT
 - request:
     method: delete
@@ -225,7 +225,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test4@example.info","message":"Bounced address has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:50 GMT
 - request:
     method: post
@@ -274,7 +274,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"message":"4 addresses have been added to the unsubscribes table"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:51 GMT
 - request:
     method: delete
@@ -318,7 +318,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test1@example.com","message":"Unsubscribe event has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:51 GMT
 - request:
     method: delete
@@ -362,7 +362,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test2@example.org","message":"Unsubscribe event has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:51 GMT
 - request:
     method: delete
@@ -406,7 +406,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test3@example.net","message":"Unsubscribe event has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:51 GMT
 - request:
     method: delete
@@ -450,7 +450,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test4@example.info","message":"Unsubscribe event has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:52 GMT
 - request:
     method: post
@@ -498,7 +498,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"message":"4 complaint addresses have been added to the complaints
         table"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:52 GMT
 - request:
     method: delete
@@ -541,7 +541,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"address":"test1@example.com","message":"Spam complaint has been removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:52 GMT
 - request:
     method: delete
@@ -584,7 +584,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"address":"test2@example.org","message":"Spam complaint has been removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:52 GMT
 - request:
     method: delete
@@ -627,7 +627,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"address":"test3@example.net","message":"Spam complaint has been removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:53 GMT
 - request:
     method: delete
@@ -671,6 +671,57 @@ http_interactions:
       encoding: UTF-8
       string: '{"address":"test4@example.info","message":"Spam complaint has been
         removed"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Nov 2016 20:53:53 GMT
+- request:
+    method: post
+    uri: https://api:<APIKEY>@api.mailgun.net/v3/DOMAIN.TEST/unsubscribes
+    body:
+      encoding: UTF-8
+      string: '[{"address":"test4@example.info","tag":"integration"},{"address":"test3@example.net","tag":"integration"},{"address":"test2@example.org","tag":"integration"},{"address":"test1@example.com","tag":"integration"}]'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin18.7.0 x86_64) ruby/2.5.7p206
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '210'
+      Host:
+      - api.mailgun.net
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - Content-Type, x-requested-with
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '600'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 04 Feb 2020 15:16:07 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Content-Length:
+      - '68'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"message":"4 addresses have been added to the unsubscribes table"}
+
+        '
+    http_version:
+  recorded_at: Tue, 04 Feb 2020 15:16:07 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
ActionMailer will try to render if body is set. However, sending body parts when template is set will result in 

```
Mailgun::CommunicationError: 400 Bad Request: Only one parameters 'html' or 'template' is allowed
```

