### PR TITLE
Possible fix for issue MIME-Version Header twice in email #194

### DIFF
--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -11,7 +11,7 @@ module Railgun
   class Mailer
 
     # List of the headers that will be ignored when copying headers from `mail.header_fields`
-    IGNORED_HEADERS = %w[ to from subject reply-to ]
+    IGNORED_HEADERS = %w[ to from subject reply-to mime-version ]
 
     # [Hash] config ->
     #   Requires *at least* `api_key` and `domain` keys.


### PR DESCRIPTION
This seems to have fixed issue #194 for us 🤔  but it seems too easy to be right, though.