### PR TITLE
Allow timeout to be passed as a config option

### DIFF
--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -32,6 +32,8 @@ module Railgun
         config[:api_host] || 'api.mailgun.net',
         config[:api_version] || 'v3',
         config[:api_ssl].nil? ? true : config[:api_ssl],
+        false,
+        config[:timeout],
       )
       @domain = @config[:domain]
 


### PR DESCRIPTION
There's currently no option to pass the `timeout` value to RestClient through Rails. This PR exposes `timeout` as a config value that could be added through action mailer settings, e.g:

```
  config.action_mailer.mailgun_settings = {
   timeout: 2
   # Other settings...
  }
```