### PR TITLE
Wrap address names in double quotes per RFC 2822

### DIFF
--- a/lib/mailgun/messages/message_builder.rb
+++ b/lib/mailgun/messages/message_builder.rb
@@ -371,7 +371,7 @@ module Mailgun
 
     # Parses the address and gracefully handles any
     # missing parameters. The result should be something like:
-    # "'First Last' <person@domain.com>"
+    # '"First Last" <person@domain.com>'
     #
     # @param [String] address The email address to parse.
     # @param [Hash] variables A list of recipient variables.
@@ -389,7 +389,7 @@ module Mailgun
         full_name = "#{vars['first']} #{vars['last']}".strip
       end 
 
-      return "'#{full_name}' <#{address}>" if defined?(full_name)
+      return "#{full_name.dump} <#{address}>" if defined?(full_name)
       address
     end
 


### PR DESCRIPTION
Right now, MessageBuilder outputs formats in this format (using single quotes)

```
From: 'John C. Doe' <john.doe@example.com>
```

However, the RFC 2822 specifies double quotes to be used as the enclosing character. As reported by one of our customers at Baremetrics, there's at least one e-mail client out there that parses the single quotes as part of the name;.

Sticking to the official format from the RFC _should_ fix that, or at least move the issue to whatever e-mail client our customer is using.

This PR changes the above output into the correct:

```
From: "John C. Doe" <john.doe@example.com>
```

If there are already double quotes in the name, they will be escaped properly:

```
From: "Jeff \"The Dude\" Lebowski" <jeff@thebiglebowski.com>
```