### PR TITLE
Send from multiple domains, fixes #161

### DIFF
--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -45,8 +45,11 @@ module Railgun
     end
 
     def deliver!(mail)
+      @mg_domain = set_mg_domain(mail)
+      mail[:domain] = nil if mail[:domain].present?
+
       mg_message = Railgun.transform_for_mailgun(mail)
-      response = @mg_client.send_message(@domain, mg_message)
+      response = @mg_client.send_message(@mg_domain, mg_message)
 
       if response.code == 200 then
         mg_id = response.to_h['id']
@@ -59,6 +62,13 @@ module Railgun
       @mg_client
     end
 
+    private
+
+    # Set @mg_domain from mail[:domain] header if present, then remove it to prevent being sent.
+    def set_mg_domain(mail)
+      return mail[:domain].value if mail[:domain]&.value&.present?
+      domain
+    end
   end
 
   module_function

--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -11,7 +11,7 @@ module Railgun
   class Mailer
 
     # List of the headers that will be ignored when copying headers from `mail.header_fields`
-    IGNORED_HEADERS = %w[ to from subject reply-to ]
+    IGNORED_HEADERS = %w[ to from subject reply-to mime-version ]
 
     # [Hash] config ->
     #   Requires *at least* `api_key` and `domain` keys.


### PR DESCRIPTION
Ability to set the sending domain from the `mail` method, see: https://github.com/mailgun/mailgun-ruby/issues/161

**Please note** this is not an ideal solution. Ideally, we should be able to define which domains are enabled in the config initializer and check whether the custom domain is included in them. If it's not, it should log an error and use the default domain instead.

Also, using `mail[:domain]` to select the custom domain feels like a workaround because `mail` is not supposed to be used like that. But it works for now :)