### PR TITLE
Support multiple sender domains. (refs #161)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ and replace `api-myapikey` and `mydomain.com` with your secret API key and domai
   }
 ```
 
+Set the `domain` setting to `auto` to automatically set the Mailgun domain based on the from address.
+```ruby
+  config.action_mailer.mailgun_settings = {
+    api_key: 'api-myapikey',
+    domain: :auto,
+  }
+```
+
 To specify Mailgun options such as campaign or tags:
 ```ruby
 class UserMailer < ApplicationMailer

--- a/lib/railgun/mailer.rb
+++ b/lib/railgun/mailer.rb
@@ -48,7 +48,8 @@ module Railgun
 
     def deliver!(mail)
       mg_message = Railgun.transform_for_mailgun(mail)
-      response = @mg_client.send_message(@domain, mg_message)
+      mg_domain = @domain.to_s == 'auto' ? extract_sender_domain(mail) : @domain
+      response = @mg_client.send_message(mg_domain, mg_message)
 
       if response.code == 200 then
         mg_id = response.to_h['id']
@@ -59,6 +60,12 @@ module Railgun
 
     def mailgun_client
       @mg_client
+    end
+
+    private
+
+    def extract_sender_domain(mail)
+      Mail::Address.new(mail.from_addrs[0]).domain
     end
 
   end


### PR DESCRIPTION
This PR is for issue #161 and similar to #214.
The different is how to determine sender address.

The different of imprements is to guess sender domain automatically from Mail::Message#from property. So when this feature use,  your imprements of ApplicationMailer need `from` property only. It is easier I think. 

Please consider to merge.