### PR TITLE
Fix deleting a domain

### DIFF
--- a/lib/mailgun/domains/domains.rb
+++ b/lib/mailgun/domains/domains.rb
@@ -75,7 +75,7 @@ module Mailgun
     # Returns [Boolean] if successful or not
     def remove(domain)
       fail(ParameterError, 'No domain given to remove on Mailgun', caller) unless domain
-      @client.delete("domains/#{domain}").to_h['message'] == 'Domain has been deleted'
+      @client.delete("domains/#{domain}").to_h['message'] == 'Domain will be deleted on the background'
     end
     alias_method :delete, :remove
     alias_method :delete_domain, :remove


### PR DESCRIPTION
Client fails to return true because it cannot find a match string in response payload. Look at the new payload below:

![image](https://user-images.githubusercontent.com/131172/133019902-89b42b50-d271-4315-8a50-e7f0040ec055.png)
