### PR TITLE
Updates the link for batch message anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ pages. Or the [Snippets](docs/Snippets.md) file.
 This SDK includes the following components:
 - [Messages](docs/Messages.md)
 - [Message Builder](docs/MessageBuilder.md)
-- [Batch Message](docs/MessageBuilder.md)
+- [Batch Message](docs/MessageBuilder.md#usage---batch-message)
 - [Opt-In Handler](docs/OptInHandler.md)
 - [Domains](docs/Domains.md)
 - [Webhooks](docs/Webhooks.md)


### PR DESCRIPTION
A small change to update the link behind the `Batch Message` heading in README file.

P.S
My first ever commit to any open source repo. 