### PR TITLE
Require railgun if Rails and ActionMailer are defined

### DIFF
--- a/lib/mailgun-ruby.rb
+++ b/lib/mailgun-ruby.rb
@@ -1,2 +1,2 @@
 require 'mailgun'
-require 'railgun' if defined?(Rails)
+require 'railgun' if defined?(Rails) && defined?(ActionMailer)


### PR DESCRIPTION
This is a fix for #254 