### PR TITLE
Add & update URLs in gemspecs

### DIFF
--- a/mailgun.gemspec
+++ b/mailgun.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
 
   spec.name             = 'mailgun-ruby'
   spec.version          = Mailgun::VERSION
-  spec.homepage         = 'http://www.mailgun.com'
+  spec.homepage         = 'https://www.mailgun.com/'
   spec.platform         = Gem::Platform::RUBY
   spec.license          = 'Apache-2.0'
 
@@ -16,6 +16,9 @@ Gem::Specification.new do |spec|
 
   spec.authors          = ['Mailgun', 'Travis Swientek']
   spec.email            = 'support@mailgunhq.com'
+
+  spec.metadata['documentation_uri'] = 'https://documentation.mailgun.com/'
+  spec.metadata['source_code_uri'] = 'https://github.com/mailgun/mailgun-ruby'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
It used to be possible to edit the URLs at rubygems.org, but this is no longer possible, so I think it's preferable to include it in the gemspec.

- https://guides.rubygems.org/specification-reference/
- https://rubygems.org/gems/mailgun-ruby

![image](https://user-images.githubusercontent.com/111689/175793414-be9c47dc-a70e-41ff-84cd-27bfca4373e5.png)
