### PR TITLE
Add missing accessors

### DIFF
--- a/lib/mailgun.rb
+++ b/lib/mailgun.rb
@@ -22,10 +22,12 @@ require 'mailgun/webhooks/webhooks'
 module Mailgun
 
   class << self
-    attr_accessor :api_key,
+    attr_accessor :api_host,
+                  :api_key,
                   :api_version,
                   :protocol,
                   :mailgun_host,
+                  :proxy_url,
                   :test_mode,
                   :domain
 


### PR DESCRIPTION
The latest version (1.2.7) of the gem is broken.
This PR: https://github.com/mailgun/mailgun-ruby/pull/262 makes calls to `Mailgun.api_host` and `Mailgun.proxy_url` but the accessors were never added.

I can't find that there are any tests for this code, so I didn't add any in this PR either. I don't really understand how the tests are structured to be honest :) But, it's a pretty bad sign when bugs like this does not break the test suite and makes it out all the way in a new gem version.

Fixes: https://github.com/mailgun/mailgun-ruby/issues/273