### PR TITLE
[Hotfix] Avoid nil responses

### DIFF
--- a/lib/mailgun/client.rb
+++ b/lib/mailgun/client.rb
@@ -206,7 +206,7 @@ module Mailgun
     # @param [StandardException] e upstream exception object
     def communication_error(e)
       if e.respond_to?(:response)
-        return case e.response.code
+        return case e.response&.code
         when Unauthorized::CODE
           Unauthorized.new(e.message, e.response)
         when BadRequest::CODE


### PR DESCRIPTION
- The exception object `e` might have a `nil` response despite responding to the method
- `CommunicationError` is already built considering this scenario, so it should be prevented here as well => https://github.com/mailgun/mailgun-ruby/blob/master/lib/mailgun/exceptions/exceptions.rb#L46

If there's an appropriate place to add a spec with an empty `e.response`, let me know! 👍 

Closes https://github.com/mailgun/mailgun-ruby/issues/289