### PR TITLE
Bump rspec version

### DIFF
--- a/mailgun.gemspec
+++ b/mailgun.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2.2'
 
   spec.add_development_dependency 'bundler', '>= 1.16.2'
-  spec.add_development_dependency 'rspec', '~> 3.8.0'
+  spec.add_development_dependency 'rspec', '~> 3.12.0'
   spec.add_development_dependency 'rake', '~> 12.3.2'
   spec.add_development_dependency 'webmock', '~> 3.7'
   spec.add_development_dependency 'pry', '~> 0.11.3'


### PR DESCRIPTION
Fixes test failures with Rails 7.1. Some tests make use of `...to receive(:abc).with(:def)`. Rails added a new method also called `with` that interferes with rspec mocks. Later versions of rspec have fixed this.

https://github.com/rspec/rspec-mocks/issues/1530