### PR TITLE
Remove base64 dependency

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'rubygems'
-require 'base64'
 require 'bundler'
 require 'bundler/setup'
 Bundler.setup(:development)


### PR DESCRIPTION
Avoids a warning with Ruby 3.3. The base64 gem will be removed as a default gem with Ruby 3.4, 3.3 will issue a warning.
Instead of adding this as a dependency to the gemspec, just use the available pack/unpack methods to which this gem is a simple wrapper.

* https://github.com/rack/rack/pull/2110
* https://github.com/rubocop/rubocop/pull/12313
* https://github.com/newrelic/newrelic-ruby-agent/pull/2378
* https://github.com/lostisland/faraday/pull/1541