### PR TITLE
Refactor to use UserNotifier instead of UserMailer for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ and replace `api-myapikey` and `mydomain.com` with your secret API key and domai
 
 To specify Mailgun options such as campaign or tags:
 ```ruby
-class UserMailer < ApplicationMailer
-  def welcome_email
-    mail(to: params[:to], subject: "Welcome!").tap do |message|
+class UserNotifier < ApplicationMailer
+  def welcome_email(current_user)
+    mail(to: current_user.email, subject: "Welcome!").tap do |message|
       message.mailgun_options = {
         "tag" => ["abtest-option-a", "beta-user"],
         "tracking-opens" => true,


### PR DESCRIPTION
This pull request refactors README.md to use the UserNotifier class instead of the UserMailer class. This change was made to ensure naming consistency throughout the document.