### PR TITLE
Work around error responses without `message` property

### DIFF
--- a/lib/mailgun/exceptions/exceptions.rb
+++ b/lib/mailgun/exceptions/exceptions.rb
@@ -50,7 +50,7 @@ module Mailgun
               end
 
       begin
-        api_message = JSON.parse(response.body)['message']
+        api_message = JSON.parse(response.body)['message'] || JSON.parse(response.body)['Error']
       rescue JSON::ParserError
         api_message = response.body
       rescue NoMethodError

--- a/lib/mailgun/exceptions/exceptions.rb
+++ b/lib/mailgun/exceptions/exceptions.rb
@@ -50,7 +50,8 @@ module Mailgun
               end
 
       begin
-        api_message = JSON.parse(response.body)['message'] || JSON.parse(response.body)['Error']
+        json = JSON.parse(response.body)
+        api_message = json['message'] || json['Error']
       rescue JSON::ParserError
         api_message = response.body
       rescue NoMethodError

--- a/lib/mailgun/exceptions/exceptions.rb
+++ b/lib/mailgun/exceptions/exceptions.rb
@@ -60,7 +60,7 @@ module Mailgun
       end
 
       message = message || ''
-      message = message + ': ' + api_message
+      message = message + ': ' + (api_message || "")
 
       super(message, response)
     rescue NoMethodError, JSON::ParserError

--- a/lib/mailgun/exceptions/exceptions.rb
+++ b/lib/mailgun/exceptions/exceptions.rb
@@ -51,7 +51,7 @@ module Mailgun
 
       begin
         json = JSON.parse(response.body)
-        api_message = json['message'] || json['Error']
+        api_message = json['message'] || json['Error'] || json['error']
       rescue JSON::ParserError
         api_message = response.body
       rescue NoMethodError

--- a/spec/unit/exceptions/exceptions_spec.rb
+++ b/spec/unit/exceptions/exceptions_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe Mailgun::CommunicationError do
           expect(subject.message).to eq("Boom!: unauthorized")
         end
       end
+
+      context "when the Response body has an `error` property" do
+        it "uses the `Error` property as the API message" do
+          subject = described_class.new('Boom!', Mailgun::Response.from_hash({ code: 401, body: '{"error":"not found"}' }))
+
+          expect(subject.message).to eq("Boom!: not found")
+        end
+      end
+
     end
   end
 end

--- a/spec/unit/exceptions/exceptions_spec.rb
+++ b/spec/unit/exceptions/exceptions_spec.rb
@@ -8,6 +8,14 @@ RSpec.describe Mailgun::CommunicationError do
           described_class.new('Boom!', Mailgun::Response.from_hash({ code: 401, body: '{}' }))
         end.not_to raise_error
       end
+
+      context "when the Response body has an `Error` property" do
+        it "uses the `Error` property as the API message" do
+          subject = described_class.new('Boom!', Mailgun::Response.from_hash({ code: 401, body: '{"Error":"unauthorized"}' }))
+
+          expect(subject.message).to eq("Boom!: unauthorized")
+        end
+      end
     end
   end
 end

--- a/spec/unit/exceptions/exceptions_spec.rb
+++ b/spec/unit/exceptions/exceptions_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe Mailgun::CommunicationError do
+  describe '.new' do
+    context "when the Response body doesn't have a `message` property" do
+      it "doesn't raise an error" do
+        expect do
+          described_class.new('Boom!', Mailgun::Response.from_hash({ code: 401, body: '{}' }))
+        end.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #295 

Currently, the body of 401 Mailgun's API responses doesn't include a `message` property. Instead, an `Error` (case-sensitive) property has the error message:

```json
{"Error":"unauthorized"}
```

This causes the current implementation of this gem to raise a runtime error instead of a `Mailgun::CommunicationError`, as expected.

This PR:
- Adds a workaround to avoid a runtime error from being raised
- Uses the `Error` property (if present) to compute the error's message
- Adds a unit test to verify this behavior

### Example of an affected API request:

```shell
curl -i -X GET \
  'https://api.mailgun.net/v3/foobar.com/events' \
  -H 'Authorization: chuchublabla'
HTTP/2 401
access-control-allow-credentials: true
access-control-allow-origin: *
cache-control: no-store
content-type: application/json
date: Tue, 24 Sep 2024 18:41:47 GMT
strict-transport-security: max-age=63072000; includeSubDomains
www-authenticate: Basic realm="MG API"
x-xss-protection: 1; mode=block
content-length: 24

{"Error":"unauthorized"}
```

I've also noticed that using `get` instead of `GET` (even though it would be incorrect) as the HTTP method will get a different API response:

```shell
curl -i -X get \
  'https://api.mailgun.net/v3/foobar.com/events' \
  -H 'Authorization: chuchublabla'
HTTP/2 404
access-control-allow-credentials: true
access-control-allow-origin: *
cache-control: no-store
content-type: application/json
date: Tue, 24 Sep 2024 19:14:52 GMT
strict-transport-security: max-age=63072000; includeSubDomains
x-xss-protection: 1; mode=block
content-length: 21

{"error":"not found"}
```

### Other insights about API HTTP 401 responses

After testing every endpoint in the OpenAPI spec file with an invalid token, all endpoints consistently respond with `{"Error":"unauthorized"}` except for these:

| HTTP Method | Endpoint | Response body |
| --- | --- | --- |
| `GET` | `/v3/domains/{domain_name}/messages/{storage_key}` | `Forbidden` |
| `DELETE` | `/v3/{domain_name}/envelopes` | (empty body) |
| `POST` | `/v3/{domain_name}/messages` | `Forbidden` |
| `POST` | `/v3/{domain_name}/messages.mime` | `Forbidden` |