### PR TITLE
Add option to specify api key and host when initializing Address api

### DIFF
--- a/lib/mailgun/address.rb
+++ b/lib/mailgun/address.rb
@@ -4,8 +4,8 @@ module Mailgun
 
   # Mailgun::Address is a simple interface to the Email Validation API.
   class Address
-    def initialize
-      @client = Mailgun::Client.new(Mailgun.api_key, Mailgun.api_host || 'api.mailgun.net', 'v4')
+    def initialize(api_key = Mailgun.api_key, api_host: Mailgun.api_host)
+      @client = Mailgun::Client.new(api_key, api_host || 'api.mailgun.net', 'v4')
     end
 
     # Given an arbitrary address, validates it based on defined checks.

--- a/lib/mailgun/address.rb
+++ b/lib/mailgun/address.rb
@@ -4,7 +4,7 @@ module Mailgun
 
   # Mailgun::Address is a simple interface to the Email Validation API.
   class Address
-    def initialize(api_key = Mailgun.api_key, api_host: Mailgun.api_host)
+    def initialize(api_key = Mailgun.api_key, api_host = Mailgun.api_host)
       @client = Mailgun::Client.new(api_key, api_host || 'api.mailgun.net', 'v4')
     end
 


### PR DESCRIPTION
The Address api currently uses the api_key and host setup on the application configuration. It would be helpful if we could
specify the key and host at runtime.