### PR TITLE
Fix: Change mime-types to runtime dependency

### DIFF
--- a/mailgun.gemspec
+++ b/mailgun.gemspec
@@ -30,12 +30,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.16.2'
   spec.add_development_dependency 'rspec', '~> 3.8.0'
   spec.add_development_dependency 'rake', '~> 12.3.2'
-  spec.add_development_dependency 'mime-types'
   spec.add_development_dependency 'webmock', '~> 3.7'
   spec.add_development_dependency 'pry', '~> 0.11.3'
   spec.add_development_dependency 'vcr', '~> 3.0.3'
   spec.add_development_dependency 'simplecov', '~> 0.16.1'
   spec.add_development_dependency 'rails'
+  spec.add_dependency 'mime-types'
   spec.add_dependency 'faraday', "~> 2.1"
 
 end


### PR DESCRIPTION
### Problem
The gem attempts to load the `mime/types` library during runtime, but the `mime-types` gem is currently listed as a development dependency in the `gemspec`. As a result, the gem is not available in production where only runtime dependencies are installed.

This leads to the following error when running the application:
```ruby
cannot load such file -- mime/types (LoadError)
```

### Solution
This pull request changes the `mime-types` dependency from a **development** to a **runtime** dependency in the `gemspec`, ensuring that `mime-types` is included in all environments where the gem is used.

Fixes #333 
