### PR TITLE
Set attachment filename on upload IO

### DIFF
--- a/lib/mailgun/messages/message_builder.rb
+++ b/lib/mailgun/messages/message_builder.rb
@@ -389,6 +389,7 @@ module Mailgun
     #
     # @param [String] parameter The message object parameter name.
     # @param [String] value The attachment.
+    # @param [String] filename Filename of the attachment.
     # @return [void]
     def add_faraday_attachment(parameter, attachment, filename)
       content_type = attachment.respond_to?(:content_type) ? attachment.content_type : nil

--- a/lib/mailgun/messages/message_builder.rb
+++ b/lib/mailgun/messages/message_builder.rb
@@ -390,9 +390,9 @@ module Mailgun
     # @param [String] parameter The message object parameter name.
     # @param [String] value The attachment.
     # @return [void]
-    def add_faraday_attachment(parameter, attachment)
+    def add_faraday_attachment(parameter, attachment, filename)
       content_type = attachment.respond_to?(:content_type) ? attachment.content_type : nil
-      @message[parameter] << Faraday::Multipart::FilePart.new(attachment, content_type)
+      @message[parameter] << Faraday::Multipart::FilePart.new(attachment, content_type, filename)
     end
 
     # Converts boolean type to string
@@ -480,7 +480,7 @@ module Mailgun
         attachment.instance_variable_set :@original_filename, filename
         attachment.instance_eval 'def original_filename; @original_filename; end'
       end
-      add_faraday_attachment(disposition, attachment)
+      add_faraday_attachment(disposition, attachment, filename)
     end
   end
 

--- a/spec/unit/messages/message_builder_spec.rb
+++ b/spec/unit/messages/message_builder_spec.rb
@@ -262,11 +262,11 @@ describe 'The method add_attachment' do
     io = StringIO.new
     io << File.binread(File.dirname(__FILE__) + "/sample_data/mailgun_icon.png")
 
-    @mb_obj.add_attachment io, 'mailgun_icon.png'
+    @mb_obj.add_attachment io, 'cool_attachment.png'
 
     expect(@mb_obj.message[:attachment].length).to eq(1)
-    expect(@mb_obj.message[:attachment].first.io.original_filename).to eq 'mailgun_icon.png'
-    expect(@mb_obj.message[:attachment].first.original_filename).to eq 'mailgun_icon.png'
+    expect(@mb_obj.message[:attachment].first.io.original_filename).to eq 'cool_attachment.png'
+    expect(@mb_obj.message[:attachment].first.original_filename).to eq 'cool_attachment.png'
   end
 
   context 'when attachment has unknown type' do

--- a/spec/unit/messages/message_builder_spec.rb
+++ b/spec/unit/messages/message_builder_spec.rb
@@ -266,6 +266,7 @@ describe 'The method add_attachment' do
 
     expect(@mb_obj.message[:attachment].length).to eq(1)
     expect(@mb_obj.message[:attachment].first.io.original_filename).to eq 'mailgun_icon.png'
+    expect(@mb_obj.message[:attachment].first.original_filename).to eq 'mailgun_icon.png'
   end
 
   context 'when attachment has unknown type' do


### PR DESCRIPTION
Fixes #349

### Description

This PR allows for filenames to be set on email attachements.

While #347 ensured that the file name was set on the IO object, it does not set it on the containing `UploadIO` object. So the filename is not set in the email attachment. This PR changes that.

### Additional Information

`Faraday::Multipart::FilePart` is actually a `::Multipart::Post::UploadIO` object as can be seen here: https://github.com/lostisland/faraday-multipart/blob/main/lib/faraday/multipart/file_part.rb#L55

This class can take an optional filename as seen here https://rubydoc.info/gems/multipart-post/2.0.0/UploadIO:initialize, it is set to `nil` as default so there is no harm passing a `nil` filename if that is ever passed from `#add_file`. As such, this PR allows for `nil` filenames as before, but also allows it to be set and actually sets it on the emails that are sent.