### PR TITLE
Honour globally configured `test_mode` as set in global config (using `Mailgun.configure`)

### DIFF
--- a/lib/mailgun/client.rb
+++ b/lib/mailgun/client.rb
@@ -15,7 +15,7 @@ module Mailgun
                    api_host = Mailgun.api_host || 'api.mailgun.net',
                    api_version = Mailgun.api_version  || 'v3',
                    ssl = true,
-                   test_mode = false,
+                   test_mode = !!Mailgun.test_mode,
                    timeout = nil,
                    proxy_url = Mailgun.proxy_url)
 


### PR DESCRIPTION
Since long time  (see #253 and 646041b) `Client` uses the defaults configured using the `Mailgun.configure` block. Somehow it skips the setup of test_mode. As it _can_ be set in the global configuration, this seems to be an inconsistency.