### PR TITLE
fix(webhooks): re-introduce url parameter

### DIFF
--- a/lib/mailgun/webhooks/webhooks.rb
+++ b/lib/mailgun/webhooks/webhooks.rb
@@ -84,7 +84,8 @@ module Mailgun
     # Returns true or false
     # :nocov:
     %i[create_all add_all_webhooks].each do |method|
-      define_method(method) do |domain|
+      define_method(method) do |domain, url|
+        url ||= ''
         warn("`#{method}` method will be deprecated in future versions of Mailgun. Please use `create` instead.")
 
         ACTIONS.each do |action|

--- a/spec/unit/webhooks_spec.rb
+++ b/spec/unit/webhooks_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Mailgun::Webhooks do
+  let(:client) { double(:client) }
+  let(:webhooks) { described_class.new(client) }
+  let(:domain) { 'example.com' }
+  let(:url) { 'https://example.com/mailgun/events' }
+
+  %i[create_all add_all_webhooks].each do |method|
+    describe "##{method}" do
+      it 'creates every webhook action with the provided URL' do
+        described_class::ACTIONS.each do |action|
+          expect(webhooks).to receive(:create).with(domain, action, url).ordered
+        end
+
+        expect { webhooks.public_send(method, domain, url) }
+          .to output(/`#{method}` method will be deprecated/).to_stderr
+      end
+    end
+  end
+end


### PR DESCRIPTION
it seems like #388 introduced an issue where `create_all` does not accept a second parameter for `url` any longer, practically breaking existing behaviour instead of just deprecating the method

## scope

+ fix deprecated bulk webhooks helpers so they accept the `url` argument again

## test

+ verify spec is red on pre-fix code